### PR TITLE
Fix downloads link

### DIFF
--- a/tpl/default.hbs
+++ b/tpl/default.hbs
@@ -46,7 +46,7 @@
                 <div class="version-pill blue"><span>{{ghostVersion}}</span></div>
             </div></h3>
             <p><b>Download</b> a development copy of Ghost, any time!</p>
-            <a href="/download/" class="button-blue-hollow">Grab the source code</a>
+            <a href="https://ghost.org/developers/" class="button-blue-hollow">Grab the source code</a>
         </article>
     </section>
 


### PR DESCRIPTION
Make the downloads link absolute to ghost.org so that it will link correctly from anywhere