### PR TITLE
fix: disable upload button on document ready event

### DIFF
--- a/public/js/gscan.js
+++ b/public/js/gscan.js
@@ -45,7 +45,9 @@
             return Math.floor(seconds) + " seconds";
     }
     $(document).ready(function ($) {
-        $('#theme-submit').prop('disabled', !$('#theme')[0].files.length);
+        if ($('#theme')[0]) {
+            $('#theme-submit').prop('disabled', !$('#theme')[0].files.length);
+        }
 
         $(document).on('change', '#theme', function () {
             $('#theme-submit').prop('disabled', !$(this)[0].files.length);


### PR DESCRIPTION
`gscan.ghost.org` has a javascript error after uploading the theme. That's why its not possible to click the button `show the details`.

```
gscan.js:48 Uncaught TypeError: Cannot read property 'files' of undefined
```