### PR TITLE
fix: clone zip object because we modify the reference

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ checkZip = function checkZip(themePath) {
             name: themePath.match(/(.*\/)?(.*).zip$/)[2]
         };
     } else {
-        zip = themePath;
+        zip = _.clone(themePath);
     }
 
     return readZip(zip).then(function thenCheckTheme(resultZip) {


### PR DESCRIPTION
If we pass an object into `checkObject`, the fn itself modifies the original object. 