### PR TITLE
use official tmp dir function from node

### DIFF
--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -1,6 +1,7 @@
 var debug      = require('ghost-ignition').debug('zip'),
     path       = require('path'),
     Promise    = require('bluebird'),
+    os         = require('os'),
     extract    = require('extract-zip'),
     uuid       = require('node-uuid'),
     _          = require('lodash'),
@@ -37,7 +38,7 @@ resolveBaseDir = function readDir(zipPath, zip) {
 
 readZip = function readZip(zip) {
     var tempUuid = uuid.v4(),
-        tempPath = (process.env.NODE_ENV === 'testing' ? './test/tmp/' : './tmp/') + tempUuid;
+        tempPath = os.tmpdir() + '/' + tempUuid;
 
     debug('Reading Zip', zip.path, 'into', tempPath);
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
When using `gscan` as a lib, it creates a `tmp` folder of the root project - that is annoying, because its just temp data. So we use the official tmp folder from `os`.

From the docu:
`The os.tmpdir() method returns a string specifying the operating system's default directory for temporary files.`