### PR TITLE
🐛 All package.json errors should be warnings

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -51,26 +51,7 @@ checkPackageJSON = function checkPackageJSON(theme) {
 
         // Rule 2: Test that the provided package.json file is valid
         return pfs.readFile(packageJSONPath, 'utf8').then(function (packageJSON) {
-            var result = PJV.validate(packageJSON), versionErrorIndex, versionErrorStr;
-
-            // a lot of themes using a wrong package.json version format, we support that
-            if (result.errors) {
-                _.each(result.errors, function (error, index) {
-                    if (error.match(/value for field version/gi)) {
-                        versionErrorIndex = index;
-                        versionErrorStr = error;
-                    }
-                });
-
-                if (versionErrorIndex !== -1) {
-                    result.errors.splice(versionErrorIndex, 1);
-                    result.warnings.push(versionErrorStr);
-                }
-
-                if (!result.errors.length) {
-                    result.valid = true;
-                }
-            }
+            var result = PJV.validate(packageJSON);
 
             if (!result.valid) {
                 // result is invalid, rule has failed
@@ -83,7 +64,7 @@ checkPackageJSON = function checkPackageJSON(theme) {
 
                 if (result.errors) {
                     theme.results.fail[validRuleCode].failures = _.map(result.errors, function (error) {
-                        return {ref: error};
+                        return {ref: 'package.json', message: error};
                     });
                 }
             } else {
@@ -109,6 +90,7 @@ checkPackageJSON = function checkPackageJSON(theme) {
         }).catch(function (error) {
             // file could not be read, rule has failed
             theme.results.fail[validRuleCode] = {
+                ref: 'package.json',
                 message: error
             };
 

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -83,7 +83,7 @@ rules = {
         "rule": "package.json file should be present."
     },
     "GS010-PJ-VAL": {
-        "level": "error",
+        "level": "warning",
         "rule": "package.json file must be valid."
     },
     "GS020-INDEX-REQ": {

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -36,34 +36,50 @@ describe('package.json', function () {
         });
     });
 
-    it('should output warnings for missing author (theme example c)', function (done) {
+    it('should output warnings ONLY for missing author (theme example c)', function (done) {
         utils.testCheck(thisCheck, 'example-c').then(function (output) {
             output.should.be.a.ValidThemeObject();
 
             output.results.fail.should.be.an.Object().which.is.empty();
+
             output.results.pass.should.be.an.Array().with.lengthOf(2);
+            output.results.pass.should.containEql('GS010-PJ-REQ');
+            output.results.pass.should.containEql('GS010-PJ-VAL');
 
             done();
         });
     });
 
-    it('should output warning for invalid package.json version (theme example g)', function (done) {
+    it('should output warning-level error for invalid version (theme example g)', function (done) {
         utils.testCheck(thisCheck, 'example-g').then(function (output) {
             output.should.be.a.ValidThemeObject();
 
-            output.results.fail.should.be.an.Object().which.is.empty();
-            output.results.pass.should.be.an.Array().with.lengthOf(2);
+            output.results.fail.should.be.an.Object().with.keys('GS010-PJ-VAL');
+            output.results.fail['GS010-PJ-VAL'].should.be.a.ValidFailObject();
+            output.results.fail['GS010-PJ-VAL'].failures.should.be.an.Array().with.lengthOf(1);
+            output.results.fail['GS010-PJ-VAL'].failures[0].should.have.keys('ref', 'message');
+
+            output.results.pass.should.be.an.Array().with.lengthOf(1);
+            output.results.pass.should.containEql('GS010-PJ-REQ');
+
 
             done();
         });
     });
 
-    it('if version is invalid and there are more errors, we expect a fail (theme example h)', function (done) {
+    it('should output warning-level errors when there are multiple errors (theme example h)', function (done) {
         utils.testCheck(thisCheck, 'example-h').then(function (output) {
             output.should.be.a.ValidThemeObject();
 
-            Object.keys(output.results.fail).length.should.eql(1);
             output.results.fail.should.be.an.Object().with.keys('GS010-PJ-VAL');
+            output.results.fail['GS010-PJ-VAL'].should.be.a.ValidFailObject();
+            output.results.fail['GS010-PJ-VAL'].failures.should.be.an.Array().with.lengthOf(2);
+            output.results.fail['GS010-PJ-VAL'].failures[0].should.have.keys('ref', 'message');
+            output.results.fail['GS010-PJ-VAL'].failures[1].should.have.keys('ref', 'message');
+
+            output.results.pass.should.be.an.Array().with.lengthOf(1);
+            output.results.pass.should.containEql('GS010-PJ-REQ');
+
 
             done();
         });


### PR DESCRIPTION
closes #15

- change the level from error to warning on the package.json rules
- this is wrong, but matches the current behaviour of Ghost