### PR TITLE
Update express-hbs for minimatch RegExp DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "1.1.1",
     "commander": "2.9.0",
     "express": "4.14.0",
-    "express-hbs": "0.8.4",
+    "express-hbs": "1.0.2",
     "extract-zip": "1.3.0",
     "fs-extra": "0.26.2",
     "ghost-ignition": "0.0.3",


### PR DESCRIPTION
* https://nodesecurity.io/advisories/minimatch_regular-expression-denial-of-service
* older express-hbs depended on older readdirp which required vulnerable minimatch 
* See PRs for context
  * https://github.com/thlorenz/readdirp/pull/43
  * https://github.com/barc/express-hbs/pull/103

Stops NPM complaining and stops my vulnerability detector going off on my Ghost server 👍 