### PR TITLE
Update express for negotiator RegExp DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "3.0.6",
     "chalk": "1.1.1",
     "commander": "2.9.0",
-    "express": "4.13.3",
+    "express": "4.14.0",
     "express-hbs": "0.8.4",
     "extract-zip": "1.3.0",
     "fs-extra": "0.26.2",


### PR DESCRIPTION
* https://nodesecurity.io/advisories/106
* older express depended on older accepts which required vulnerable negotiator 
* See PRs for context
  * https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c
  * https://github.com/expressjs/express/pull/3006