### PR TITLE
fix: match partials on windows

### DIFF
--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -55,7 +55,7 @@ readHbsFiles = function readHbsFiles(theme) {
 
     return Promise.map(_.where(theme.files, {ext: '.hbs'}), function (themeFile) {
         return pfs.readFile(path.join(theme.path, themeFile.file), 'utf8').then(function (content) {
-            var partialMatch = themeFile.file.match(/^partials\/(.*)+\.hbs$/);
+            var partialMatch = themeFile.file.match(/^partials\/?\\?(.*)+\.hbs$/);
             themeFile.content = content;
 
             try {


### PR DESCRIPTION
closes #22

gscan was not able to match partials on windows