### PR TITLE
Production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "bluebird": "3.0.6",
-    "chalk": "1.1.1",
+    "chalk": "1.1.3",
     "commander": "2.9.0",
     "express": "4.14.0",
     "express-hbs": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ghost-ignition": "0.0.4",
     "glob": "7.0.6",
     "lodash": "3.10.1",
-    "multer": "1.1.0",
+    "multer": "1.2.0",
     "node-uuid": "1.4.7",
     "package-json-validator": "0.6.0",
     "require-dir": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gscan",
-  "version": "0.0.13",
+  "version": "0.0.11",
   "description": "Scans Ghost themes looking for errors, deprecations, features and compatibility",
   "keywords": [
     "ghost",
@@ -37,7 +37,7 @@
     "express": "4.14.0",
     "express-hbs": "1.0.3",
     "extract-zip-fork": "1.5.1",
-    "fs-extra": "0.26.2",
+    "fs-extra": "0.30.0",
     "ghost-ignition": "0.0.4",
     "glob": "7.0.6",
     "lodash": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "multer": "1.2.0",
     "node-uuid": "1.4.7",
     "package-json-validator": "0.6.0",
-    "require-dir": "0.1.0"
+    "require-dir": "0.3.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "extract-zip-fork": "1.5.1",
     "fs-extra": "0.26.2",
     "ghost-ignition": "0.0.4",
-    "glob": "7.0.5",
+    "glob": "7.0.6",
     "lodash": "3.10.1",
     "multer": "1.1.0",
     "node-uuid": "1.4.7",


### PR DESCRIPTION
This PR includes all of the easily upgradable production dependencies.
- Package.json-validator shows as 0.6.1 in npm but I don't know what is in it as there's no trace of it on GitHub. Have [raised an issue](https://github.com/gorillamania/package.json-validator/issues/55) and will update when I know
- lodash & bluebird are slightly more tricky upgrades, that need more testing 
- express-hbs is in a separate PR already
