### PR TITLE
⬆️ Update extract-zip to custom fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "commander": "2.9.0",
     "express": "4.14.0",
     "express-hbs": "1.0.3",
-    "extract-zip": "1.3.0",
+    "extract-zip": "https://github.com/ErisDS/extract-zip/tarball/issue-30",
     "fs-extra": "0.26.2",
     "ghost-ignition": "0.0.3",
     "glob": "7.0.5",


### PR DESCRIPTION
- Fixes issue where unzipping misidentifies directories and causes gscan to crash