### PR TITLE
Convert the asset helper rule to a warning + provide rule codes in results

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -45,7 +45,7 @@ format = function format(theme) {
 
     _.each(theme.results.fail, function (info, code) {
         var rule = spec.rules[code];
-        theme.results[rule.level].push(_.extend({}, rule, info));
+        theme.results[rule.level].push(_.extend({}, rule, info, {code: code}));
         stats[rule.level]++;
         processedCodes.push(code);
     });
@@ -54,7 +54,7 @@ format = function format(theme) {
 
     _.each(theme.results.pass, function (code, index) {
         var rule = spec.rules[code];
-        theme.results.pass[index] = rule;
+        theme.results.pass[index] = _.extend({}, rule, {code: code});
         stats[rule.level]++;
         processedCodes.push(code);
     });

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -99,9 +99,10 @@ rules = {
         "rule": "Provide a default layout template called default.hbs."
     },
     "GS030-ASSET-REQ": {
-        "level": "error",
+        "level": "warning",
         "rule": "Assets such as CSS & JS must use the <code>{{asset}}</code> helper",
-        "details": "<p>The listed files should be included using the <code>{{asset}}</code> helper.</p>"
+        "details": "<p>The listed files should be included using the <code>{{asset}}</code> helper. "
+            + " For more information, please see the <a href=\"http://themes.ghost.org/docs/asset\">asset helper documentation</a>.</p>"
     },
     "GS040-GH-REQ": {
         "level": "warning",


### PR DESCRIPTION
These two little fixes will allow us to downgrade the asset helper rule to a warning. 

Merging this is dependent on us having some UI changes ready in Ghost: see #7367 and #7362