### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/middlewares/log-request.js
+++ b/app/middlewares/log-request.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid'),
+var uuid = require('uuid'),
     logging = require('../logging');
 
 /**

--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -4,7 +4,7 @@ var debug      = require('ghost-ignition').debug('zip'),
     os         = require('os'),
     glob       = require('glob'),
     extract    = require('extract-zip-fork'),
-    uuid       = require('node-uuid'),
+    uuid       = require('uuid'),
     _          = require('lodash'),
     readZip,
     resolveBaseDir;

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "glob": "7.0.5",
     "lodash": "3.10.1",
     "multer": "1.1.0",
-    "node-uuid": "1.4.7",
     "package-json-validator": "0.6.0",
-    "require-dir": "0.1.0"
+    "require-dir": "0.1.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.