### PR TITLE
🐛 Fixes ignored file removal by making it conditional to tmp directory

### DIFF
--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird'),
     _       = require('lodash'),
+    os     = require('os'),
     hbs     = require('express-hbs'),
     path    = require('path'),
     pfs     = require('./promised-fs'),
@@ -10,7 +11,10 @@ var Promise = require('bluebird'),
     readHbsFiles;
 
 readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
+    themePath = path.join(themePath, '.');
     subPath = subPath || '';
+    tmpPath = os.tmpdir();
+    inTmp = themePath.substr(0, tmpPath.length) === tmpPath,
     arr = arr || [];
 
     var makeResult = function makeResult(result, subFilePath, ext) {
@@ -25,7 +29,7 @@ readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
         return Promise.reduce(files, function (result, file) {
             var extMatch = file.match(/.*?(\..+$)/),
                 subFilePath = path.join(subPath, file),
-                newPath;
+                newPath = path.join(themePath, file);
 
             /**
              * don't process ignored paths, remove target file
@@ -36,27 +40,22 @@ readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
              * - what we don't support right now is to delete the ignore files from the zip
              */
             if (ignore.indexOf(file) > -1) {
-                return pfs.removeFile(path.join(themePath, file))
-                    .then(function () {
-                        return result;
-                    });
+                return inTmp
+                    ? pfs.removeFile(newPath)
+                        .then(function () {
+                            return result;
+                        })
+                    : result;
             }
 
-            // If it has an extension, treat it as a file
-            if (extMatch) {
-                return makeResult(result, subFilePath, extMatch[1]);
-            } else {
-                newPath = path.join(themePath, file);
-
-                // NOTE: lstat does not follow symlinks
-                return pfs.lstatFile(newPath).then(function (statFile) {
-                    if (statFile.isDirectory()) {
-                        return readThemeStructure(newPath, subFilePath, result);
-                    } else {
-                        return makeResult(result, subFilePath);
-                    }
-                });
-            }
+            // NOTE: lstat does not follow symlinks
+            return pfs.lstatFile(newPath).then(function (statFile) {
+                if (statFile.isDirectory()) {
+                    return readThemeStructure(newPath, subFilePath, result);
+                } else {
+                    return makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined);
+                }
+            });
         }, arr);
     });
 };

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -133,6 +133,19 @@ describe('check zip', function () {
                     assetFiles.should.eql(['default.hbs']);
                 });
         });
+
+        it('Don\'t remove files if theme not in tmp directory', function () {
+            return checker(themePath('example-l'))
+                .then(function (theme) {
+                    theme.files.length.should.eql(1);
+                    theme.files[0].file.should.match(/default\.hbs/);
+
+                    return pfs.readDir(path.join(theme.path, 'assets'));
+                })
+                .then(function (assetFiles) {
+                    assetFiles.should.eql(['Thumbs.db', 'default.hbs']);
+                });
+        });
     });
 });
 
@@ -192,7 +205,7 @@ describe('Read Hbs Files', function () {
         });
     });
 
-   it('can read partials with windows paths', function (done) {
+    it('can read partials with windows paths', function (done) {
        // This matches Example I, but on Windows
        var exampleI = [
            { file: 'index.hbs', ext: '.hbs' },


### PR DESCRIPTION
closes #43

- always make theme path absolute
- remove file if filename in ignored list and theme path in tmp directory
- ignore file if filename in ignored list and them path not in tmp directory

From my understanding of the `gscan` module, these are the possible use cases and the code branches they are expected to take:

1) CLI mode & path to a folder
=> ignore files & check theme
2) CLI mode & path to a ZIP file
=> extract to tmp directory, remove ignored files & check theme
3) Web interface mode & upload ZIP file
=> extract to tmp directory, remove ignored files & check theme
4) Lib mode & path to a folder (e.g: Ghost's validate theme feature)
=> ignore files & check theme
5) Lib mode & path to a ZIP file (e.g: Ghost's upload theme feature)
=> extract to tmp directory, remove ignored files & check theme

This flow should thus make sure that any theme uploaded is safe while at the same time using a more relaxed theme check (no file removals) on already uploaded ones.

Symbolic links that don't have an ignored filename or are contained in a folder with an ignored filename will be caught by the theme checker rule [`GS030-ASSET-SYM`](https://github.com/TryGhost/gscan/blob/master/lib/checks/030-assets.js#L26).