### PR TITLE
🐛 Fixes blocking of upload if no file or no ZIP file

### DIFF
--- a/app/public/js/gscan.js
+++ b/app/public/js/gscan.js
@@ -46,11 +46,23 @@
     }
     $(document).ready(function ($) {
         if ($('#theme')[0]) {
-            $('#theme-submit').prop('disabled', !$('#theme')[0].files.length);
+            $('#theme')
+                .siblings('label')
+                .attr('for', $(this).attr('id'))
+                .toggle(false);
+            $('#theme-submit').prop('disabled', true);
         }
 
         $(document).on('change', '#theme', function () {
-            $('#theme-submit').prop('disabled', !$(this)[0].files.length);
+            var files = $(this)[0].files;
+            var hasFiles = files.length;
+            var isZip = hasFiles && files[0].name.split('.').pop() === 'zip';
+
+            $(this)
+                .siblings('label')
+                .attr('for', $(this).attr('id'))
+                .toggle(!isZip);
+            $('#theme-submit').prop('disabled', !isZip);
         });
 
         /** Latest News **/

--- a/app/tpl/index.hbs
+++ b/app/tpl/index.hbs
@@ -6,8 +6,11 @@
         </header>
         <section class="gh-gscan-uploader">
             <form action="/" method="post" enctype="multipart/form-data" class="clearfix">
-                <input type="file" name="theme" id="theme" />
-                <button class="gh-btn gh-btn-blue" id="theme-submit" type="submit"><span>Upload</span></button>
+                <label class="gh-error-message" for="theme">File type needs to be ZIP (.zip extension).</label>
+                <br/>
+                <input type="file" accept="application/zip"
+ name="theme" id="theme" />
+                <button class="btn gh-btn gh-btn-blue" id="theme-submit" type="submit"><span>Upload</span></button>
             </form>
         </section>
 


### PR DESCRIPTION
closes #4

- button is disabled until a file has been uploaded and it's type is ZIP
- use file input tag's accept attribute to only allow uploads of files with MIME type application/file
- fallback to file type detection based on file extension for older browsers and show an error message if not a ZIP file

Note: Here's a list of browsers that don't support the `accept` attribute for `input[type=file]` tags: http://caniuse.com/#feat=input-file-accept