### PR TITLE
🔥  ✨  rename known helpers: image -> img_url

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -8,7 +8,7 @@ var knownHelpers, templates, rules, ruleNext;
 
 knownHelpers = [
     // Ghost
-    'foreach', 'has', 'is', 'get', 'content', 'excerpt', 'title', 'tags', 'author', 'image', 'navigation', 'pagination',
+    'foreach', 'has', 'is', 'get', 'content', 'excerpt', 'title', 'tags', 'author', 'img_url', 'navigation', 'pagination',
     'page_url', 'url', 'date', 'plural', 'encode', 'asset', 'body_class', 'post_class', 'ghost_head', 'ghost_foot',
     'meta_title', 'meta_description', 'next_post', 'prev_post', 'twitter_url', 'facebook_url',
     // Ghost apps
@@ -128,7 +128,7 @@ ruleNext = {
     },
     "GS035-CONTENT-0": {
         "level": "warning",
-        "rule": "Replace the content zero hack with the {{image}} helper"
+        "rule": "Replace the content zero hack with the {{img_url}} helper"
     }
 };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8348

**It's time to release gscan 1.0.**.
Alternatively we could support both image and img_url helper, but that is a little unclear and dirty?

If this PR get's merged, we have to support/release two different gscan versions.
Master will be the newest changes (=== 1.x)