### PR TITLE
Regex hangs

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -77,7 +77,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
 
     _.each(checks, function (check) {
         _.each(theme.files, function (themeFile) {
-            var template = themeFile.file.match(/^[^\/]+.hbs$/) || themeFile.file.match(/^partials[\/\\]+(.*)+\.hbs$/),
+            var template = themeFile.file.match(/^[^\/]+.hbs$/) || themeFile.file.match(/^partials[\/\\]+(.*)\.hbs$/),
                 css = themeFile.file.match(/\.css/),
                 cssDeprecations;
 

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -66,7 +66,7 @@ readHbsFiles = function readHbsFiles(theme) {
 
     return Promise.map(_.where(theme.files, {ext: '.hbs'}), function (themeFile) {
         return pfs.readFile(path.join(theme.path, themeFile.file), 'utf8').then(function (content) {
-            var partialMatch = themeFile.file.match(/^partials[\/\\]+(.*)+\.hbs$/);
+            var partialMatch = themeFile.file.match(/^partials[\/\\]+(.*)\.hbs$/);
             themeFile.content = content;
 
             try {

--- a/test/fixtures/themes/001-deprecations/valid/partials/this-is-a-very-long-path.hbs.old
+++ b/test/fixtures/themes/001-deprecations/valid/partials/this-is-a-very-long-path.hbs.old
@@ -1,0 +1,4 @@
+{{author.cover_image}}
+
+{{!-- invalid usage of author property. Will not be detected. --}}
+{{author_cover_image}}


### PR DESCRIPTION
The regex to filter hbs files is written in a way that it can create a
condition where gscan will hang forever. This is similar to an endless
loop and not handled with an exception in JS Regex. This condition is
also referred to as „catastrophic backtrack“.

Pre Condition:
- hbs and a second extension (e.g.: .hbs.old)
- part of the partials folder
- relatively long filename/filepath (> 35 chars)

Changes:
- changed/optimized regex
- added test file to reproduce the case