### PR TITLE
Provide fake data to hbs compiler

### DIFF
--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -7,7 +7,8 @@ var _       = require('lodash'),
 checkTemplatesCompile = function checkTemplatesCompile(theme) {
     var ruleCode = 'GS005-TPL-ERR',
         localHbs = hbs.create(),
-        failures = [];
+        failures = [],
+        missingHelper;
 
     _.each(theme.partials, function (partial) {
         var partialContent = _.find(theme.files, {file: 'partials/' + partial + '.hbs'}).content;
@@ -32,10 +33,25 @@ checkTemplatesCompile = function checkTemplatesCompile(theme) {
             try {
                 // When we read the theme, we precompile, here we compile with registered partials and helpers
                 // Which will let us detect any missing partials, helpers or parse errors
-                compiled = localHbs.handlebars.compile(themeFile.content);
-                // We need to provide a minimum dataset to enable certain blocks such as {{#post}}.. to execute
+                compiled = localHbs.handlebars.compile(themeFile.content, {
+                    knownHelpers: _.zipObject(spec.knownHelpers, _.map(spec.knownHelpers, function() { return true; })),
+                    knownHelpersOnly: true
+                });
+
+                // NOTE: fakeData does not resolve finding unknown helpers in context objects!
                 compiled(fakeData(themeFile));
             } catch (error) {
+                // CASE: transform ugly error message from hbs to the known error message: Missing helper: "X"
+                if (error.message.match(/you specified knownhelpersOnly/gi)) {
+                    try {
+                        missingHelper = error.message.match(/but\sused\sthe\sunknown\shelper\s(.*)\s-/)[1];
+                    } catch(err) {
+                        missingHelper = 'unknown helper name';
+                    }
+
+                    error.message = 'Missing helper: "' + missingHelper + '"';
+                }
+
                 failures.push({
                     ref: themeFile.file,
                     message: error.message

--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -1,7 +1,8 @@
 var _       = require('lodash'),
     hbs     = require('express-hbs'),
     spec    = require('../spec.js'),
-    checkTemplatesCompile;
+    checkTemplatesCompile,
+    fakeData = require('../faker');
 
 checkTemplatesCompile = function checkTemplatesCompile(theme) {
     var ruleCode = 'GS005-TPL-ERR',
@@ -14,7 +15,12 @@ checkTemplatesCompile = function checkTemplatesCompile(theme) {
     });
 
     _.each(spec.knownHelpers, function (helper) {
-        localHbs.handlebars.registerHelper(helper, _.noop);
+        // Use standard handlebars {{each}} method for simplicity
+        if (helper === 'foreach') {
+            localHbs.handlebars.registerHelper('foreach', hbs.handlebars.helpers.each);
+        } else {
+            localHbs.handlebars.registerHelper(helper, _.noop);
+        }
     });
 
     _.each(theme.files, function (themeFile) {
@@ -27,7 +33,8 @@ checkTemplatesCompile = function checkTemplatesCompile(theme) {
                 // When we read the theme, we precompile, here we compile with registered partials and helpers
                 // Which will let us detect any missing partials, helpers or parse errors
                 compiled = localHbs.handlebars.compile(themeFile.content);
-                compiled({});
+                // We need to provide a minimum dataset to enable certain blocks such as {{#post}}.. to execute
+                compiled(fakeData(themeFile));
             } catch (error) {
                 failures.push({
                     ref: themeFile.file,

--- a/lib/faker/index.js
+++ b/lib/faker/index.js
@@ -1,0 +1,59 @@
+var fakeData = function fakeData(themeFile) {
+    var tag = {
+        id: '345678901',
+        name: 'hill',
+        description: 'tag for hill',
+        feature_image: '/content/2017/07/tag-image.jpg',
+        meta_title: 'meta title for hill tag',
+        meta_description: 'meta description for hill tag',
+        url: 'http://talltalesofhighhills.com/tag/hill'
+    };
+
+    var author = {
+        id: '234567890',
+        name: 'John McHill',
+        slug: 'john-mchill',
+        bio: 'I "Troll" through hills',
+        location: 'On top of a hill',
+        website: 'http://hills.com',
+        twitter: '/hill',
+        facebook: '/hill',
+        profile_image: '/content/2017/07/johnmchill.jpg',
+        cover_image: '/content/2017/07/johnmchillontopofahighhill.jpg',
+        url: 'http:///talltalesofhighhills.com/author/john-mchill'
+    };
+
+    var post = {
+        id: '123456789',
+        title: 'The highs and lows of hills',
+        slug: 'the-highs-and-low-of-hills',
+        excerpt: 'Hills can be hilly',
+        content: "Hills can be hilly when they are like hills",
+        url: "http://talltalesofhighhills.com/the-highs-and-low-of-hills",
+        feature_image: '/content/2017/07/highhill.jpg',
+        featured: 0,
+        page: 0,
+        meta_title: 'The hill felt hilly  - how meta is that?',
+        meta_description: 'a meta description about a meta description hmm...',
+        published_at: '2017-07-01T12:00:00.000Z' ,
+        update_at: '2017-07-01T12:00:00.000Z',
+        created_at: '2017-07-01T12:00:00.000Z',
+        author: author,
+        tags: [{tag: tag}]
+    };
+
+    // Initialise data for index/home hbs templates
+    var postsData = {posts: [post], pagination: {}};
+
+    if (themeFile.file.match(/^post/) || themeFile.file.match(/^page/)) {
+        postsData = {post: post};
+    } else if (themeFile.file.match(/^tag/)) {
+        postsData = {tag: tag, pagination: {}};
+    } else if (themeFile.file.match(/^author/)) {
+        postsData = {author: author, pagination: {}};
+    }
+
+    return postsData;
+};
+
+module.exports = fakeData;

--- a/test/005-template-compile.test.js
+++ b/test/005-template-compile.test.js
@@ -38,14 +38,20 @@ describe('Template compile', function () {
             output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
             var failures = output.results.fail['GS005-TPL-ERR'].failures;
-            failures[0].ref.should.eql('index.hbs');
-            failures[0].message.should.match(/^The partial/);
 
-            failures[1].ref.should.eql('page.hbs');
-            failures[1].message.should.match(/^Parse error/);
+            failures.length.should.eql(4);
 
-            failures[2].ref.should.eql('post.hbs');
-            failures[2].message.should.match(/^Missing helper/);
+            failures[0].ref.should.eql('author.hbs');
+            failures[0].message.should.match(/^Missing helper: "bla"/);
+
+            failures[1].ref.should.eql('index.hbs');
+            failures[1].message.should.match(/^The partial/);
+
+            failures[2].ref.should.eql('page.hbs');
+            failures[2].message.should.match(/^Parse error/);
+
+            failures[3].ref.should.eql('post.hbs');
+            failures[3].message.should.match(/^Missing helper: "my-helper"/);
 
             done();
         }).catch(done);

--- a/test/fixtures/themes/005-compile/invalid/author.hbs
+++ b/test/fixtures/themes/005-compile/invalid/author.hbs
@@ -1,0 +1,4 @@
+{{#author}}
+    <h1>hello</h1>
+    {{bla "string"}}
+{{/author}}


### PR DESCRIPTION
closes #63
- provides fake data to allow author/post/tag blocks to execute
- uses handlebars {{each}} helper to replace {{foreach}} helper