### PR TITLE
🚨 Add checks for {{id}} and disqus embeds

### DIFF
--- a/lib/checks/002-comment-id.js
+++ b/lib/checks/002-comment-id.js
@@ -1,0 +1,48 @@
+var _ = require('lodash'),
+    checkCommentID;
+
+checkCommentID = function checkCommentID(theme, themePath) {
+    var checks = [
+        // Check 1:
+        // Look for instances of: this.page.identifier = 'ghost-{{id}}';
+        // Also the old style disqus embed: var disqus_identifier = 'ghost-{{id}}';
+        {
+            regex: /(page\.|disqus_)identifier\s?=\s?['"].*?({{\s*?id\s*?}}).*?['"];?/g,
+            ruleCode: 'GS002-DISQUS-ID'
+        },
+        // Check 2:
+        // Look for other usages of {{id}}
+        {
+            regex: /({{\s*?id\s*?}})/g,
+            ruleCode: 'GS002-ID-HELPER'
+        }
+    ];
+
+    _.each(checks, function (check) {
+        _.each(theme.files, function (themeFile) {
+            var template = themeFile.file.match(/^[^\/]+.hbs$/) || themeFile.file.match(/^partials[\/\\]+(.*)\.hbs$/);
+
+            if (template) {
+                if (themeFile.content.match(check.regex)) {
+                    if (!theme.results.fail.hasOwnProperty(check.ruleCode)) {
+                        theme.results.fail[check.ruleCode] = {failures: []};
+                    }
+
+                    theme.results.fail[check.ruleCode].failures.push(
+                        {
+                            ref: themeFile.file
+                        }
+                    );
+                }
+            }
+        });
+
+        if (theme.results.pass.indexOf(check.ruleCode) === -1 && !theme.results.fail.hasOwnProperty(check.ruleCode)) {
+            theme.results.pass.push(check.ruleCode);
+        }
+    });
+
+    return theme;
+};
+
+module.exports = checkCommentID;

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -287,6 +287,27 @@ rules = {
         "details": "The <code>.page-template-slug</code> CSS class was replaced with the <code>.page-slug</code>. Please replace this in your stylesheet.<br>" +
                    "See the <a href=\"https://themes.ghost.org/docs/context-overview#section-context-table\" target=_blank>context table</a> to check which classes Ghost uses for each context."
     },
+    "GS002-DISQUS-ID": {
+        "level": "error",
+        "rule": "Replace <code>{{id}}</code> with <code>{{comment_id}}</code> in Disqus embeds.",
+        "fatal": true,
+        "details": "The output of <code>{{id}}</code> has changed between Ghost LTS and 1.0.0. " +
+                    "This results in Disqus comments not loading on Ghost 1.0.0 posts which were imported from Ghost LTS. " +
+                    "To resolve this, we've added a new <code>{{comment_id}}</code> helper that will output the old ID " +
+                    "for posts that have been imported from LTS, and the new ID for new posts. " +
+                    "The Disqus embed must be updated from <code>this.page.identifier = 'ghost-{{id}}';</code> to " +
+                    "<code>this.page.identifier = 'ghost-{{comment_id}}';</code> to ensure Disqus continues to work."
+    },
+    "GS002-ID-HELPER": {
+        "level": "warning",
+        "rule": "The output of <code>{{id}}</code> changed between Ghot LTS and 1.0.0, you may need to use <code>{{comment_id}}</code> instead.",
+        "details": "The output of <code>{{id}}</code> has changed between Ghost LTS and 1.0.0. " +
+                    "<code>{{id}}</code> used to output an incrementing integer ID, and will now output an ObjectID. " +
+                    "We've added a new <code>{{comment_id}}</code> helper that will output the old ID " +
+                    "for posts that have been imported from LTS, and the new ID for new posts. " +
+                    "If you need the old ID to be output on imported posts, then you will need to use " +
+                    "<code>{{comment_id}}</code> rather than <code>{{id}}</code>."
+    },
     "GS005-TPL-ERR": {
         "level": "error",
         "rule": "Templates must contain valid Handlebars",

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -249,7 +249,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(29);
+            theme.results.pass.should.be.an.Array().with.lengthOf(31);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(


### PR DESCRIPTION
See https://github.com/TryGhost/Ghost/issues/8760 for the reasoning behind these additional checks.

Here's my regex101 test ground for the  regex which looks for the Disqus embed: https://regex101.com/r/AFj5Ml/3

- Ghost 1.0 changed id format from integers to ObjectID strings
- This breaks disqus comments 😞
- We're rolling out an emergency workaround to use `{{comment_id}}` instead
- This will contain the old id for posts that get migrated from LTS
- Anyone using the disqus embed MUST update their theme in order to keep comments
- Anyone using `{{id}}` MAY also want to switch over to the new property