### PR TITLE
🎨  downgrade id helper detection to recommendation

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -299,7 +299,7 @@ rules = {
                     "<code>this.page.identifier = 'ghost-{{comment_id}}';</code> to ensure Disqus continues to work."
     },
     "GS002-ID-HELPER": {
-        "level": "warning",
+        "level": "recommendation",
         "rule": "The output of <code>{{id}}</code> changed between Ghost LTS and 1.0.0, you may need to use <code>{{comment_id}}</code> instead.",
         "details":
                     "<strong>This warning can be ignored if you are using Casper or a closely related theme.</strong> " +


### PR DESCRIPTION
refs #78

- the id helper regex is too general and detects all {{id}} usages (e.g. in get helper usages)
- there is no quick way to modify the existing regex to cover all cases or we could cover some cases, but there is a risk to run into more edge cases and then have to spend time again fixing them
- downgrading it to a recommendation is the easiest way for now
- recommendations should only appear on gscan.ghost.org