### PR TITLE
✨ Tweaked ppp spec to include being > 0 

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -36,8 +36,12 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
         failed.push(packageJSONValidationRules.versionIsSemverCompliant);
     }
 
-    if (!packageJSON.config || !packageJSON.config.posts_per_page) {
+    if (!packageJSON.config || _.isNil(packageJSON.config.posts_per_page)) {
         failed.push(packageJSONValidationRules.configPPPIsRequired);
+        passedRulesToOmit.push('configPPIsInteger');
+    } else if (!_.isNumber(packageJSON.config.posts_per_page) || packageJSON.config.posts_per_page < 1) {
+        failed = _.without(failed, packageJSONValidationRules.configPPPIsRequired);
+        failed.push(packageJSONValidationRules.configPPIsInteger);
     }
 
     if (!packageJSON.author || !packageJSON.author.email) {
@@ -61,16 +65,7 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
         failed.push(packageJSONValidationRules.authorEmailIsValid);
     }
 
-    if (packageJSON.config && packageJSON.config.posts_per_page && !_.isNumber(packageJSON.config.posts_per_page)) {
-        failed = _.without(failed, packageJSONValidationRules.configPPPIsRequired);
-        failed.push(packageJSONValidationRules.configPPIsInteger);
-    }
-
     _.extend(theme.results.fail, _private.getFailedRules(failed));
-
-    if (failed.indexOf(packageJSONValidationRules.configPPPIsRequired) !== -1) {
-        passedRulesToOmit.push('configPPIsInteger');
-    }
 
     // add intersection as passed
     theme.results.pass = theme.results.pass.concat(_.xor(failed, _.values(_.omit(packageJSONValidationRules, passedRulesToOmit))));

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -376,8 +376,8 @@ rules = {
     },
     "GS010-PJ-CONF-PPP-INT": {
         "level": "error",
-        "rule": "<code>package.json</code> property <code>\"config.posts_per_page\"</code> must be integer",
-        "details": "The property <code>\"config.posts_per_page\"</code> in your <code>package.json</code> file must be integer. E.g. <code>{\"config\": { \"posts_per_page\": 5}}</code>.<br>" +
+        "rule": "<code>package.json</code> property <code>\"config.posts_per_page\"</code> must be a number above 0",
+        "details": "The property <code>\"config.posts_per_page\"</code> in your <code>package.json</code> file must be a number greater than zero. E.g. <code>{\"config\": { \"posts_per_page\": 5}}</code>.<br>" +
                    "Check the <a href=\"https://themes.ghost.org/docs/packagejson#section--config-posts_per_page-\" target=_blank><code>package.json</code> documentation</a> for further information."
     },
     "GS010-PJ-AUT-EM-REQ": {

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -26,7 +26,7 @@ describe('010: package.json', function () {
 
             output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
             done();
-        });
+        }).catch(done);
     });
 
     it('should output error for missing package.json', function (done) {
@@ -51,7 +51,7 @@ describe('010: package.json', function () {
 
             output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
             done();
-        });
+        }).catch(done);
     });
 
     it('should output error for invalid package.json (parsing)', function (done) {
@@ -79,7 +79,7 @@ describe('010: package.json', function () {
             output.results.fail['GS010-PJ-PARSE'].failures[0].message.should.containEql('Unexpected token');
 
             done();
-        });
+        }).catch(done);
     });
 
     it('valid fields', function (done) {
@@ -102,7 +102,7 @@ describe('010: package.json', function () {
 
             theme.results.fail.should.be.an.Object().which.is.empty();
             done();
-        });
+        }).catch(done);
     });
 
     it('invalid fields', function (done) {
@@ -126,7 +126,7 @@ describe('010: package.json', function () {
                 'GS010-PJ-CONF-PPP-INT'
             );
             done();
-        });
+        }).catch(done);
     });
 
     it('missing fields', function (done) {
@@ -150,6 +150,54 @@ describe('010: package.json', function () {
             );
 
             done();
-        });
+        }).catch(done);
+    });
+
+    it('bad config (ppp: -3 > 0)', function (done) {
+        utils.testCheck(thisCheck, '010-packagejson/bad-config').then(function (theme) {
+            theme.should.be.a.ValidThemeObject();
+
+            theme.results.pass.should.eql([
+                'GS010-PJ-REQ',
+                'GS010-PJ-PARSE',
+                'GS010-PJ-NAME-REQ',
+                'GS010-PJ-NAME-LC',
+                'GS010-PJ-NAME-HY',
+                'GS010-PJ-VERSION-SEM',
+                'GS010-PJ-VERSION-REQ',
+                'GS010-PJ-AUT-EM-VAL',
+                'GS010-PJ-AUT-EM-REQ',
+                'GS010-PJ-CONF-PPP'
+            ]);
+
+            theme.results.fail.should.be.an.Object().with.keys(
+                'GS010-PJ-CONF-PPP-INT'
+            );
+            done();
+        }).catch(done);
+    });
+
+    it('bad config 2 (ppp: 0 > 0)', function (done) {
+        utils.testCheck(thisCheck, '010-packagejson/bad-config-2').then(function (theme) {
+            theme.should.be.a.ValidThemeObject();
+
+            theme.results.pass.should.eql([
+                'GS010-PJ-REQ',
+                'GS010-PJ-PARSE',
+                'GS010-PJ-NAME-REQ',
+                'GS010-PJ-NAME-LC',
+                'GS010-PJ-NAME-HY',
+                'GS010-PJ-VERSION-SEM',
+                'GS010-PJ-VERSION-REQ',
+                'GS010-PJ-AUT-EM-VAL',
+                'GS010-PJ-AUT-EM-REQ',
+                'GS010-PJ-CONF-PPP'
+            ]);
+
+            theme.results.fail.should.be.an.Object().with.keys(
+                'GS010-PJ-CONF-PPP-INT'
+            );
+            done();
+        }).catch(done);
     });
 });

--- a/test/fixtures/themes/010-packagejson/bad-config-2/package.json
+++ b/test/fixtures/themes/010-packagejson/bad-config-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-theme",
+  "version": "0.0.1",
+  "author": {
+    "email": "theme@example.org"
+  },
+  "config": {
+    "posts_per_page": 0
+  }
+}

--- a/test/fixtures/themes/010-packagejson/bad-config/package.json
+++ b/test/fixtures/themes/010-packagejson/bad-config/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-theme",
+  "version": "0.0.1",
+  "author": {
+    "email": "theme@example.org"
+  },
+  "config": {
+    "posts_per_page": -3
+  }
+}

--- a/test/fixtures/themes/010-packagejson/valid/package.json
+++ b/test/fixtures/themes/010-packagejson/valid/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "ATheme_test",
-  "version": "0.1"
-}


### PR DESCRIPTION
Requires #81 

no issue

- Requires lodash upgrade as _.isNil was added in v4
- Posts per page needs to be a number > 0
- Simplified the logic around posts_per_page
- Ensuring this is validated properly allows us to remove some logic from Ghost