### PR TITLE
🛠 Updated npm scripts to match other projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "scripts": {
     "start": "node app/index.js",
-    "test": "mocha"
+    "dev": "NODE_ENV=development DEBUG=gscan:* nodemon",
+    "test": "NODE_ENV=testing mocha -- $(find test -name '*.test.js')"
   },
   "bin": {
     "gscan": "./bin/cli.js"
@@ -55,6 +56,7 @@
     "grunt-shipit": "1.0.0",
     "istanbul": "0.4.1",
     "mocha": "2.4.5",
+    "nodemon": "1.11.0",
     "rewire": "2.5.2",
     "shipit-deploy": "2.1.3",
     "should": "7.1.0",


### PR DESCRIPTION
no issue

- We commonly use `npm run dev` to start in development mode
- Adds nodemon as a dependency (we already have nodemon config in the repo)