### PR TITLE
Add reading_time helper to list of known helpers

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -10,7 +10,7 @@ knownHelpers = [
     // Ghost
     'foreach', 'has', 'is', 'get', 'content', 'excerpt', 'title', 'tags', 'author', 'img_url', 'navigation', 'pagination',
     'page_url', 'url', 'date', 'plural', 'encode', 'asset', 'body_class', 'post_class', 'ghost_head', 'ghost_foot',
-    'meta_title', 'meta_description', 'next_post', 'prev_post', 'twitter_url', 'facebook_url',
+    'meta_title', 'meta_description', 'next_post', 'prev_post', 'twitter_url', 'facebook_url', 'reading_time',
     // Ghost apps
     'input_email', 'input_password', 'amp_components', 'amp_content', 'amp_ghost_head', 'subscribe_form',
     // Handlebars and express handlebars


### PR DESCRIPTION
Was added in [Ghost 1.13.0](http://themes.ghost.org/docs/changelog#section-ghost-1130)