### PR TITLE
Allow custom helpers in env variable

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -18,7 +18,7 @@ knownHelpers = [
     'log', 'if', 'unless', 'with', 'block', 'contentFor', 'each', 'lookup'
     // Registering these will break template compile checks
     // 'blockHelperMissing', 'helperMissing',
-];
+].concat((process.env.GSCAN_ALLOW_HELPERS || "").split(","));
 
 templates = [
     {


### PR DESCRIPTION
This allows users to create custom apps that specify templates and allow them through ENV variables. This makes it hard to activate, but possible for developers (so only the people who should be using custom helpers use custom helpers).