### PR TITLE
deprecation: added checks for single author usages

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -146,8 +146,63 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
         {
             helperRegEx: /{{\s*?#author\s*?}}/g,
             helperName: '{{#author}}',
-            ruleCode: 'GS001-DEPR-A'
+            ruleCode: 'GS001-DEPR-AUTH'
         },
+        {
+            helperRegEx: /{{\s*?#author(.)id}}/g,
+            helperName: '{{#author.id}}',
+            ruleCode: 'GS001-DEPR-AUTH-ID'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)name}}/g,
+            helperName: '{{#author.name}}',
+            ruleCode: 'GS001-DEPR-AUTH-NAME'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)bio}}/g,
+            helperName: '{{#author.bio}}',
+            ruleCode: 'GS001-DEPR-AUTH-BIO'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)location}}/g,
+            helperName: '{{#author.location}}',
+            ruleCode: 'GS001-DEPR-AUTH-LOC'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)website}}/g,
+            helperName: '{{#author.website}}',
+            ruleCode: 'GS001-DEPR-AUTH-WEB'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)twitter}}/g,
+            helperName: '{{#author.twitter}}',
+            ruleCode: 'GS001-DEPR-AUTH-TW'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)facebook}}/g,
+            helperName: '{{#author.facebook}}',
+            ruleCode: 'GS001-DEPR-AUTH-FB'
+        },
+        {
+            helperRegEx: /{{\s*?#author(.)profile_image}}/g,
+            helperName: '{{#author.profile_image}}',
+            ruleCode: 'GS001-DEPR-AUTH-PROIM'
+        }, 
+        {
+            helperRegEx: /{{\s*?#author(.)cover_image}}/g,
+            helperName: '{{#author.cover_image}}',
+            ruleCode: 'GS001-DEPR-AUTH-COIM'
+        }, 
+        {
+            helperRegEx: /{{\s*?#author(.)url}}/g,
+            helperName: '{{#author.url}}',
+            ruleCode: 'GS001-DEPR-AUTH-URL'
+        }, 
+        {
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.+\sfilter="(author:.+|.+author:.+)"}}/g,
+            helperName: 'filter=author:[...]',
+            ruleCode: 'GS001-DEPR-AUTH-FIL'
+        },                                                                                
     ];
 
     _.each(checks, function (check) {

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -139,7 +139,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             ruleCode: 'GS001-DEPR-CSS-PATS'
         },
         {
-            helperRegEx: /{{\s*?#get\s*?"posts"\s*?include="(author|author,.+|.+,author|.+,author,.+)"\s*?}}/g,
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.+include="(author|author,.+|.+,author|.+,author,.+)"\s.*}}/g,
             helperName: 'include="author"',
             ruleCode: 'GS001-DEPR-GIA'
         },
@@ -199,7 +199,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             ruleCode: 'GS001-DEPR-AUTH-URL'
         }, 
         {
-            helperRegEx: /{{\s*?#get\s*?"posts"\s.+\sfilter="(author:.+|.+author:.+)"}}/g,
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.+\sfilter="(author:.+|.+author:.+)"\s.*}}/g,
             helperName: 'filter=author:[...]',
             ruleCode: 'GS001-DEPR-AUTH-FIL'
         },                                                                                

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -202,6 +202,11 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             helperRegEx: /{{\s*?#get\s*?"posts"\s.*filter="(author:.+|.+author:.+)"\s.*}}/g,
             helperName: 'filter=author:[...]',
             ruleCode: 'GS001-DEPR-AUTH-FIL'
+        }, 
+        {
+            helperRegEx: /{{\s*?#foreach (author\s.+|author\s|author)}}/g,
+            helperName: '{{#foreach author}}',
+            ruleCode: 'GS001-DEPR-AUTH-FORE'
         },                                                                                
     ];
 

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -199,7 +199,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             ruleCode: 'GS001-DEPR-AUTH-URL'
         }, 
         {
-            helperRegEx: /{{\s*?#get\s*?"posts"\s.*\sfilter="(author:.+|.+author:.+)"\s.*}}/g,
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.*filter="(author:.+|.+author:.+)"\s.*}}/g,
             helperName: 'filter=author:[...]',
             ruleCode: 'GS001-DEPR-AUTH-FIL'
         },                                                                                

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -139,7 +139,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             ruleCode: 'GS001-DEPR-CSS-PATS'
         },
         {
-            helperRegEx: /{{\s*?#get\s*?"posts"\s.+include="(author|author,.+|.+,author|.+,author,.+)"\s.*}}/g,
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.*include="(author|author,.*.+|.+,.*author|.+,.*author,.+)"\s.*}}/g,
             helperName: 'include="author"',
             ruleCode: 'GS001-DEPR-GIA'
         },
@@ -199,7 +199,7 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             ruleCode: 'GS001-DEPR-AUTH-URL'
         }, 
         {
-            helperRegEx: /{{\s*?#get\s*?"posts"\s.+\sfilter="(author:.+|.+author:.+)"\s.*}}/g,
+            helperRegEx: /{{\s*?#get\s*?"posts"\s.*\sfilter="(author:.+|.+author:.+)"\s.*}}/g,
             helperName: 'filter=author:[...]',
             ruleCode: 'GS001-DEPR-AUTH-FIL'
         },                                                                                

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -137,7 +137,17 @@ checkDeprecations = function checkDeprecations(theme, themePath) {
             className: '.page-template-slug',
             css: true,
             ruleCode: 'GS001-DEPR-CSS-PATS'
-        }
+        },
+        {
+            helperRegEx: /{{\s*?#get\s*?"posts"\s*?include="(author|author,.+|.+,author|.+,author,.+)"\s*?}}/g,
+            helperName: 'include="author"',
+            ruleCode: 'GS001-DEPR-GIA'
+        },
+        {
+            helperRegEx: /{{\s*?#author\s*?}}/g,
+            helperName: '{{#author}}',
+            ruleCode: 'GS001-DEPR-A'
+        },
     ];
 
     _.each(checks, function (check) {

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -436,7 +436,19 @@ rules = {
         "details": "The <code>{{ghost_foot}}</code> helper should be present in your theme. It outputs scripts as saved in <a href=\"https://help.ghost.org/hc/en-us/articles/223403488-Code-Injection\" target=_blank>\"code injection\" scripts</a>.<br>" +
                    "The helper belongs just before the <code></body></code> tag in your <code>default.hbs</code> template.<br>" +
                    "For more details, please see the <a href=\"https://themes.ghost.org/docs/ghost_foot\" target=_blank><code>{{ghost_foot}}</code> helper documentation</a>."
-    }
+    },
+    "GS001-DEPR-GIA": {
+        "level": "error",
+        "rule": "<code>include='author'</code> should be replaced with <code>include='authors'</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>author</code> is no longer valid and should be" +
+                   "replaced with <code>authors</code>"
+    },
+    "GS001-DEPR-A": {
+        "level": "error",
+        "rule": "<code>{{#author}}</code> should be replaced with <code>{{#authors}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>author</code> is no longer valid and should be" +
+                   "replaced with <code>authors</code>"
+    },
 };
 
 /**

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -440,15 +440,81 @@ rules = {
     "GS001-DEPR-GIA": {
         "level": "error",
         "rule": "<code>include='author'</code> should be replaced with <code>include='authors'</code>",
-        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>author</code> is no longer valid and should be" +
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>author</code> is no longer valid and should be " +
                    "replaced with <code>authors</code>"
     },
-    "GS001-DEPR-A": {
+    "GS001-DEPR-AUTH": {
         "level": "error",
         "rule": "<code>{{#author}}</code> should be replaced with <code>{{#authors}}</code>",
-        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>author</code> is no longer valid and should be" +
-                   "replaced with <code>authors</code>"
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors}}</code>"
     },
+    "GS001-DEPR-AUTH-ID": {
+        "level": "error",
+        "rule": "<code>{{#author.id}}</code> should be replaced with <code>{{#authors.id}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.id}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.id}}</code>"
+    },
+    "GS001-DEPR-AUTH-NAME": {
+        "level": "error",
+        "rule": "<code>{{#author.name}}</code> should be replaced with <code>{{#authors.name}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.name}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.name}}</code>"
+    },
+    "GS001-DEPR-AUTH-BIO": {
+        "level": "error",
+        "rule": "<code>{{#author.bio}}</code> should be replaced with <code>{{#authors.bio}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.bio}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.bio}}</code>"
+    },
+    "GS001-DEPR-AUTH-LOC": {
+        "level": "error",
+        "rule": "<code>{{#author.location}}</code> should be replaced with <code>{{#authors.location}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{author.location}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{authors.location}}</code>"
+    },
+    "GS001-DEPR-AUTH-WEB": {
+        "level": "error",
+        "rule": "<code>{{#author.website}}</code> should be replaced with <code>{{#authors.website}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.website}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.website}}</code>"
+    },
+    "GS001-DEPR-AUTH-TW": {
+        "level": "error",
+        "rule": "<code>{{#author.twitter}}</code> should be replaced with <code>{{#authors.twitter}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.twitter}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.twitter}}</code>"
+    },
+    "GS001-DEPR-AUTH-FB": {
+        "level": "error",
+        "rule": "<code>{{#author.facebook}}</code> should be replaced with <code>{{#authors.facebook}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.facebook}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.facebook}}</code>"
+    },
+    "GS001-DEPR-AUTH-PROIM": {
+        "level": "error",
+        "rule": "<code>{{#author.profile_image}}</code> should be replaced with <code>{{#authors.profile_image}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.profile_image}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.profile_image}}</code>"
+    },
+    "GS001-DEPR-AUTH-COIM": {
+        "level": "error",
+        "rule": "<code>{{#author.cover_image}}</code> should be replaced with <code>{{#authors.cover_image}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.cover_image}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.cover_image}}</code>"
+    },
+    "GS001-DEPR-AUTH-URL": {
+        "level": "error",
+        "rule": "<code>{{#author.url}}</code> should be replaced with <code>{{#authors.url}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#author.url}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#authors.url}}</code>"
+    },
+    "GS001-DEPR-AUTH-FIL": {
+        "level": "error",
+        "rule": "<code>filter=author:[...]</code> should be replaced with <code>filter=authors:[...]</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>filter=author:[...]</code> is no longer valid and should be " +
+                   "replaced with <code>filter=authors:[...]</code>"
+    },                                        
 };
 
 /**

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -514,6 +514,12 @@ rules = {
         "rule": "<code>filter=author:[...]</code> should be replaced with <code>filter=authors:[...]</code>",
         "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>filter=author:[...]</code> is no longer valid and should be " +
                    "replaced with <code>filter=authors:[...]</code>"
+    }, 
+    "GS001-DEPR-AUTH-FORE": {
+        "level": "error",
+        "rule": "<code>{{#foreach author}}</code> should be replaced with <code>{{#foreach authors}}</code>",
+        "details": "Ghost 1.22.0 introduced multiple authors for posts. This change means that <code>{{#foreach author}}</code> is no longer valid and should be " +
+                   "replaced with <code>{{#foreach authors}}</code>"
     },                                        
 };
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -38,7 +38,18 @@ describe('001 Deprecations', function () {
                 'GS001-DEPR-CSS-PA',
                 'GS001-DEPR-CSS-PATS',
                 'GS001-DEPR-GIA',
-                'GS001-DEPR-A',
+                'GS001-DEPR-AUTH',
+                'GS001-DEPR-AUTH-ID',
+                'GS001-DEPR-AUTH-NAME',
+                'GS001-DEPR-AUTH-BIO',
+                'GS001-DEPR-AUTH-LOC',
+                'GS001-DEPR-AUTH-WEB',
+                'GS001-DEPR-AUTH-TW',
+                'GS001-DEPR-AUTH-FB',
+                'GS001-DEPR-AUTH-PROIM',
+                'GS001-DEPR-AUTH-COIM',
+                'GS001-DEPR-AUTH-URL',
+                'GS001-DEPR-AUTH-FIL',
             );
 
             // pageUrl
@@ -137,9 +148,53 @@ describe('001 Deprecations', function () {
             output.results.fail['GS001-DEPR-GIA'].should.be.a.ValidFailObject();
             output.results.fail['GS001-DEPR-GIA'].failures.length.should.eql(1);
 
-            // {{author}}
-            output.results.fail['GS001-DEPR-A'].should.be.a.ValidFailObject();
-            output.results.fail['GS001-DEPR-A'].failures.length.should.eql(1);
+            // {{#author}}
+            output.results.fail['GS001-DEPR-AUTH'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH'].failures.length.should.eql(1);
+
+            // {{#author.id}}
+            output.results.fail['GS001-DEPR-AUTH-ID'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-ID'].failures.length.should.eql(1);            
+
+            // {{#author.name}}
+            output.results.fail['GS001-DEPR-AUTH-NAME'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-NAME'].failures.length.should.eql(1);  
+
+            // {{#author.bio}}
+            output.results.fail['GS001-DEPR-AUTH-BIO'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-BIO'].failures.length.should.eql(1);
+
+            // {{#author.location}}
+            output.results.fail['GS001-DEPR-AUTH-LOC'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-LOC'].failures.length.should.eql(1); 
+
+            // {{#author.website}}
+            output.results.fail['GS001-DEPR-AUTH-WEB'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-WEB'].failures.length.should.eql(1);            
+
+            // {{#author.twitter}}
+            output.results.fail['GS001-DEPR-AUTH-TW'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-TW'].failures.length.should.eql(1);  
+
+            // {{#author.facebook}}
+            output.results.fail['GS001-DEPR-AUTH-FB'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-FB'].failures.length.should.eql(1);
+
+            // {{#author.profile_image}}
+            output.results.fail['GS001-DEPR-AUTH-PROIM'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-PROIM'].failures.length.should.eql(1);             
+
+            // {{#author.cover_image}}
+            output.results.fail['GS001-DEPR-AUTH-COIM'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-COIM'].failures.length.should.eql(1);
+            
+            // {{#author.url}}
+            output.results.fail['GS001-DEPR-AUTH-URL'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-URL'].failures.length.should.eql(1); 
+            
+            // filter=author:[...]
+            output.results.fail['GS001-DEPR-AUTH-FIL'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-FIL'].failures.length.should.eql(1);             
 
             output.results.pass.should.be.an.Object().which.is.empty();
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -50,6 +50,7 @@ describe('001 Deprecations', function () {
                 'GS001-DEPR-AUTH-COIM',
                 'GS001-DEPR-AUTH-URL',
                 'GS001-DEPR-AUTH-FIL',
+                'GS001-DEPR-AUTH-FORE',
             );
 
             // pageUrl
@@ -194,7 +195,11 @@ describe('001 Deprecations', function () {
             
             // filter=author:[...]
             output.results.fail['GS001-DEPR-AUTH-FIL'].should.be.a.ValidFailObject();
-            output.results.fail['GS001-DEPR-AUTH-FIL'].failures.length.should.eql(1);             
+            output.results.fail['GS001-DEPR-AUTH-FIL'].failures.length.should.eql(1);  
+
+            // {{#foreach author}}
+            output.results.fail['GS001-DEPR-AUTH-FORE'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-AUTH-FORE'].failures.length.should.eql(1);  
 
             output.results.pass.should.be.an.Object().which.is.empty();
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -36,7 +36,9 @@ describe('001 Deprecations', function () {
                 'GS001-DEPR-TIMG',
                 'GS001-DEPR-CSS-AT',
                 'GS001-DEPR-CSS-PA',
-                'GS001-DEPR-CSS-PATS'
+                'GS001-DEPR-CSS-PATS',
+                'GS001-DEPR-GIA',
+                'GS001-DEPR-A',
             );
 
             // pageUrl
@@ -130,6 +132,14 @@ describe('001 Deprecations', function () {
             // css class .achive-template
             output.results.fail['GS001-DEPR-CSS-AT'].should.be.a.ValidFailObject();
             output.results.fail['GS001-DEPR-CSS-AT'].failures.length.should.eql(1);
+
+            // {{#get "posts" include="author"}}
+            output.results.fail['GS001-DEPR-GIA'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-GIA'].failures.length.should.eql(1);
+
+            // {{author}}
+            output.results.fail['GS001-DEPR-A'].should.be.a.ValidFailObject();
+            output.results.fail['GS001-DEPR-A'].failures.length.should.eql(1);
 
             output.results.pass.should.be.an.Object().which.is.empty();
 


### PR DESCRIPTION
This PR adds additional checks to Gscan now that Ghost allows [multiple authors on posts](https://github.com/TryGhost/Ghost/releases/tag/1.22.0), themes should replace instances of `author` with `authors`.

Below is a list of what it will pick up on. Comments welcome on anything that I've missed but I think I've got the majority of usages.

#### Helper
`{{author}}`

#### Helper Objects
`{{author.id}}`
`{{author.name}}`
`{{author.bio}}`
`{{author.location}}`
`{{author.website}}`
`{{author.twitter}}`
`{{author.facebook}}`
`{{author.profile_image}}`
`{{author.cover_image}}`
`{{author.url}}`

#### Include 
`{{#get "posts" include="tags,author"}}`
`{{#get "posts" include="author"}}`
`{{#get "posts" include="tags,author,slug"}}`
`{{#get "posts" include="author,tags"}}`
`{{#get "posts" include="author, tags"}}` (space between includes)

#### Filter
`{{#get "posts" filter="featured:true+author:author_name"}}`
`{{#get "posts" filter="author:author_name"}}`
`{{#get "posts" filter="author:author_name+featured:true"}}`
`{{#get "posts" filter="author:{{primary_author.slug}}+id:-{{id}}"}}`
`{{#get "posts" filter="authors:{{primary_author.slug}}+id:-{{id}}"))`

#### Foreach
`{{#foreach author}}`
`{{#foreach author as |author|}}`