### PR TITLE
🔥 Drop Node v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "git@github.com:TryGhost/gscan.git"
   },
+  "engine": {
+    "node": ">=6"
+  },
   "bugs": {
     "url": "https://github.com/TryGhost/gscan/issues"
   },


### PR DESCRIPTION
no issue

- https://github.com/nodejs/Release
- disable running Node v4 tests in travis
- added engine to package.json `>=6`