### PR TITLE
Fixed the command line for installing gscan globally with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Visit https://gscan.ghost.org and upload your zip to our online version of Gscan
 
 Install using yarn / npm:
 
-`yarn global add gscan` /  `npm install -G gscan`
+`yarn global add gscan` /  `npm install -g gscan`
 
 To run a local directory through the checks:
 


### PR DESCRIPTION
There was a typo in the command-line for the npm installation, it was enough to break it for me, the correct option is a lower-case g. Simple fix, might help someone, definitely won't break anything.
