### PR TITLE
Update links to docs to last major version

### DIFF
--- a/app/tpl/index.hbs
+++ b/app/tpl/index.hbs
@@ -4,7 +4,7 @@
             <h1>Scan Your Theme</h1>
             <p class="gh-subhead">Upload a zip to check for errors, deprecations and other compatibility issues.</p>
             <p class="gh-subhead warning"><strong>GScan validates your theme based on the Ghost 1.0 requirements.</strong></p>
-            <a href="https://themes.ghost.org/docs/changelog#ghost-100-beta" target=_blank class="gh-morelink">
+            <a href="https://themes.ghost.org/v1.25.0/docs/changelog#ghost-100-beta" target=_blank class="gh-morelink">
                 See the changelog for Ghost 1.0 themes
                 <svg viewBox="0 0 18 27" xmlns="http://www.w3.org/2000/svg"><path d="M2.397 25.426l13.143-11.5-13.143-11.5" stroke-width="3" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>
             </a>

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -80,14 +80,14 @@ rules = {
         rule: 'Replace <code>{{pageUrl}}</code> with <code>{{page_url}}</code>',
         fatal: true,
         details: 'The helper <code>{{pageUrl}}</code> was replaced with <code>{{page_url}}</code>.<br>' +
-                   'Find more information about the <code>{{page_url}}</code> helper <a href="https://themes.ghost.org/docs/page_url" target=_blank>here</a>.'
+                   'Find more information about the <code>{{page_url}}</code> helper <a href="https://themes.ghost.org/v1.25.0/docs/page_url" target=_blank>here</a>.'
     },
     'GS001-DEPR-MD': {
         level: 'error',
         rule: 'The usage of <code>{{meta_description}}</code> in HTML <code>head</code> is no longer required',
         details: 'The usage of <code>{{meta_description}}</code> in the HTML <code>head</code> tag is no longer required because Ghost outputs this for you automatically in <code>{{ghost_head}}</code>.<br>' +
-                   'Check out the documentation for <code>{{meta_description}}</code> <a href="https://themes.ghost.org/docs/meta_description" target=_blank>here</a>.<br>' +
-                   'To see, what else is rendered with the <code>{{ghost_head}}</code> helper, look <a href="https://themes.ghost.org/docs/ghost_head" target=_blank>here</a>.'
+                   'Check out the documentation for <code>{{meta_description}}</code> <a href="https://themes.ghost.org/v1.25.0/docs/meta_description" target=_blank>here</a>.<br>' +
+                   'To see, what else is rendered with the <code>{{ghost_head}}</code> helper, look <a href="https://themes.ghost.org/v1.25.0/docs/ghost_head" target=_blank>here</a>.'
     },
     'GS001-DEPR-IMG': {
         level: 'error',
@@ -96,8 +96,8 @@ rules = {
         details: 'The <code>{{image}}</code> helper was replaced with the <code>{{img_url}}</code> helper.<br>' +
                    'Depending on the context of the <code>{{img_url}}</code> helper you would need to use e. g. <br><br><code>{{#post}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{img_url feature_image}}<br>{{/post}}</code><br><br>to render the feature image of the blog post.<br>' +
                    '<br><b>If you are using <code>{{if image}}</code></b>, then you have to replace it with e.g. <code>{{if feature_image}}.</code>' +
-                   '<br><br>Find more information about the <code>{{img_url}}</code> helper <a href="https://themes.ghost.org/docs/img_url" target=_blank>here</a> and ' +
-                   'read more about Ghost\'s usage of contexts <a href="https://themes.ghost.org/docs/context-overview" target=_blank>here</a>.'
+                   '<br><br>Find more information about the <code>{{img_url}}</code> helper <a href="https://themes.ghost.org/v1.25.0/docs/img_url" target=_blank>here</a> and ' +
+                   'read more about Ghost\'s usage of contexts <a href="https://themes.ghost.org/v1.25.0/docs/context-overview" target=_blank>here</a>.'
     },
     'GS001-DEPR-COV': {
         level: 'error',
@@ -105,8 +105,8 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>. To render the cover image in author context, you need to use<br><br>' +
                    '<code>{{#author}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{cover_image}}<br>{{/author}}</code><br><br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br>' +
-                   'To render the cover image of your blog, just use <code>{{@blog.cover_image}}</code>. See <a href="https://themes.ghost.org/docs/blog" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br>' +
+                   'To render the cover image of your blog, just use <code>{{@blog.cover_image}}</code>. See <a href="https://themes.ghost.org/v1.25.0/docs/blog" target=_blank>here</a>.'
     },
     'GS001-DEPR-AIMG': {
         level: 'error',
@@ -114,7 +114,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in author context was replaced with <code>profile_image</code>.<br>' +
                    'Instead of <code>{{author.image}}</code> you need to use <code>{{author.profile_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-PIMG': {
         level: 'error',
@@ -122,7 +122,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in post context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{post.image}}</code> you need to use <code>{{post.feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>post</code> <a href="https://themes.ghost.org/docs/post-context#section-post-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>post</code> <a href="https://themes.ghost.org/v1.25.0/docs/post-context#section-post-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-BC': {
         level: 'error',
@@ -130,7 +130,7 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>' +
                    'Instead of <code>{{@blog.cover}}</code> you need to use <code>{{@blog.cover_image}}</code>.<br>' +
-                   'See <a href="https://themes.ghost.org/docs/blog" target=_blank>here</a>.'
+                   'See <a href="https://themes.ghost.org/v1.25.0/docs/blog" target=_blank>here</a>.'
     },
     'GS001-DEPR-AC': {
         level: 'error',
@@ -138,7 +138,7 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>' +
                    'Instead of <code>{{author.cover}}</code> you need to use <code>{{author.cover_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-TIMG': {
         level: 'error',
@@ -146,7 +146,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{tag.image}}</code> you need to use <code>{{tag.feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-PAIMG': {
         level: 'error',
@@ -154,7 +154,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in author context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{post.author.image}}</code> you need to use <code>{{post.author.feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-PAC': {
         level: 'error',
@@ -162,7 +162,7 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute in author context was replaced with <code>cover_image</code>.<br>' +
                    'Instead of <code>{{post.author.cover}}</code> you need to use <code>{{post.author.cover_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-PTIMG': {
         level: 'error',
@@ -170,7 +170,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{post.tags.[#].image}}</code> you need to use <code>{{post.tags.[#].feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-TSIMG': {
         level: 'error',
@@ -178,7 +178,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{tags.[#].image}}</code> you need to use <code>{{tags.[#].feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-IMG': {
         level: 'error',
@@ -186,19 +186,19 @@ rules = {
         '{{#if profile_image}}</code>',
         fatal: true,
         details: 'The <code>image</code> attribute was replaced with <code>feature_image</code> and <code>profile_image</code>.<br>' +
-                   'Depending on the <a href="https://themes.ghost.org/docs/context-overview" target=_blank>context</a> you will need to replace it like this:<br><br>' +
+                   'Depending on the <a href="https://themes.ghost.org/v1.25.0/docs/context-overview" target=_blank>context</a> you will need to replace it like this:<br><br>' +
                    '<code>{{#author}}<br>' +
                    '&nbsp;&nbsp;&nbsp;&nbsp;{{#if profile_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{profile_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{/if}}<br>' +
                    '{{/author}}</code><br><br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br><br>' +
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br><br>' +
                    '<code>{{#post}}<br>' +
                    '&nbsp;&nbsp;&nbsp;&nbsp;{{#if feature_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{feature_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{/if}}<br>' +
                    '{{/post}}</code><br><br>' +
-                   'See the object attributes of <code>post</code> <a href="https://themes.ghost.org/docs/post-context#section-post-object-attributes" target=_blank>here</a>.<br><br>' +
+                   'See the object attributes of <code>post</code> <a href="https://themes.ghost.org/v1.25.0/docs/post-context#section-post-object-attributes" target=_blank>here</a>.<br><br>' +
                    '<code>{{#tag}}<br>' +
                    '&nbsp;&nbsp;&nbsp;&nbsp;{{#if feature_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{feature_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{/if}}<br>' +
                    '{{/tag}}</code><br><br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-COV': {
         level: 'error',
@@ -206,8 +206,8 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>. To check for the cover image in author context, you need to use<br><br>' +
                    '<code>{{#if cover_image}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{cover_image}}<br>{{/if}}</code><br><br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br>' +
-                   'To check for the cover image of your blog, just use <code>{{#if @blog.cover_image}}</code>. See <a href="https://themes.ghost.org/docs/blog" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.<br>' +
+                   'To check for the cover image of your blog, just use <code>{{#if @blog.cover_image}}</code>. See <a href="https://themes.ghost.org/v1.25.0/docs/blog" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-BC': {
         level: 'error',
@@ -215,7 +215,7 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>' +
                    'Instead of <code>{{#if @blog.cover}}</code> you need to use <code>{{#if @blog.cover_image}}</code>.<br>' +
-                   'See <a href="https://themes.ghost.org/docs/blog" target=_blank>here</a>.'
+                   'See <a href="https://themes.ghost.org/v1.25.0/docs/blog" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-AC': {
         level: 'error',
@@ -223,7 +223,7 @@ rules = {
         fatal: true,
         details: 'The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>' +
                    'Instead of <code>{{#if author.cover}}</code> you need to use <code>{{#if author.cover_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-AIMG': {
         level: 'error',
@@ -231,7 +231,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in author context was replaced with <code>profile_image</code>.<br>' +
                    'Instead of <code>{{#if author.image}}</code> you need to use <code>{{#if author.profile_image}}</code>.<br>' +
-                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>author</code> <a href="https://themes.ghost.org/v1.25.0/docs/author-context#section-author-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-TIMG': {
         level: 'error',
@@ -239,7 +239,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{#if tag.image}}</code> you need to use <code>{{#if tag.feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-PTIMG': {
         level: 'error',
@@ -247,7 +247,7 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{#if post.tags.[#].image}}</code> you need to use <code>{{#if post.tags.[#].feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-CON-TSIMG': {
         level: 'error',
@@ -255,38 +255,38 @@ rules = {
         fatal: true,
         details: 'The <code>image</code> attribute in tag context was replaced with <code>feature_image</code>.<br>' +
                    'Instead of <code>{{#if tags.[#].image}}</code> you need to use <code>{{#if tags.[#].feature_image}}</code>.<br>' +
-                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
+                   'See the object attributes of <code>tags</code> <a href="https://themes.ghost.org/v1.25.0/docs/tag-context#section-tag-object-attributes" target=_blank>here</a>.'
     },
     'GS001-DEPR-PPP': {
         level: 'error',
         rule: 'Replace <code>{{@blog.posts_per_page}}</code> with <code>{{@config.posts_per_page}}</code>',
         details: 'The global <code>{{@blog.posts_per_page}}</code> property was replaced with <code>{{@config.posts_per_page}}</code>.<br>' +
-                   'Read <a href="https://themes.ghost.org/docs/config" target=_blank>here</a> about the attribute and ' +
-                   'check <a href="https://themes.ghost.org/docs/packagejson#section--config-posts_per_page-" target=_blank>here</a> where you can customise the posts per page setting, as this is now adjustable in your theme.'
+                   'Read <a href="https://themes.ghost.org/v1.25.0/docs/config" target=_blank>here</a> about the attribute and ' +
+                   'check <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--config-posts_per_page-" target=_blank>here</a> where you can customise the posts per page setting, as this is now adjustable in your theme.'
     },
     'GS001-DEPR-C0H': {
         level: 'error',
         rule: 'Replace <code>{{content words="0"}}</code> with the <code>{{img_url}}</code> helper',
         details: 'The <code>{{content words="0"}}</code> hack doesn\'t work anymore (and was never supported). Please use the <code>{{img_url}}</code> helper to render images.<br>' +
-                   'Find more information about the <code>{{img_url}}</code> helper <a href="https://themes.ghost.org/docs/img_url" target=_blank>here</a> and '
+                   'Find more information about the <code>{{img_url}}</code> helper <a href="https://themes.ghost.org/v1.25.0/docs/img_url" target=_blank>here</a> and '
     },
     'GS001-DEPR-CSS-AT': {
         level: 'error',
         rule: 'Replace <code>.archive-template</code> with the <code>.paged</code> CSS class',
         details: 'The <code>.archive-template</code> CSS class was replaced with the <code>.paged</code>. Please replace this in your stylesheet.<br>' +
-                   'See the <a href="https://themes.ghost.org/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
+                   'See the <a href="https://themes.ghost.org/v1.25.0/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
     },
     'GS001-DEPR-CSS-PA': {
         level: 'error',
         rule: 'Replace <code>.page</code> with the <code>.page-template</code> css class',
         details: 'The <code>.page</code> CSS class was replaced with the <code>.page-template</code>. Please replace this in your stylesheet.<br>' +
-                   'See the <a href="https://themes.ghost.org/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
+                   'See the <a href="https://themes.ghost.org/v1.25.0/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
     },
     'GS001-DEPR-CSS-PATS': {
         level: 'error',
         rule: 'Replace <code>.page-template-slug</code> with the <code>.page-slug</code> css class',
         details: 'The <code>.page-template-slug</code> CSS class was replaced with the <code>.page-slug</code>. Please replace this in your stylesheet.<br>' +
-                   'See the <a href="https://themes.ghost.org/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
+                   'See the <a href="https://themes.ghost.org/v1.25.0/docs/context-overview#section-context-table" target=_blank>context table</a> to check which classes Ghost uses for each context.'
     },
     'GS002-DISQUS-ID': {
         level: 'error',
@@ -315,19 +315,19 @@ rules = {
         rule: 'Templates must contain valid Handlebars',
         fatal: true,
         details: 'Oops! You seemed to have used invalid Handlebars syntax. This mostly happens, when you use a helper that is not supported.<br>' +
-                   'See the full list of available helpers <a href="https://themes.ghost.org/docs/helpers" target=_blank>here</a>.'
+                   'See the full list of available helpers <a href="https://themes.ghost.org/v1.25.0/docs/helpers" target=_blank>here</a>.'
     },
     'GS010-PJ-REQ': {
         level: 'error',
         rule: '<code>package.json</code> file should be present',
         details: 'You should provide a <code>package.json</code> file for your theme.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
     },
     'GS010-PJ-PARSE': {
         level: 'error',
         rule: '<code>package.json</code> file can be parsed',
         details: 'Your <code>package.json</code> file couldn\'t be parsed. This is mostly caused by a missing or unnecessary <code>\',\'</code> or the wrong usage of <code>\'""\'</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson" target=_blank><code>package.json</code> documentation</a> for further information.<br>' +
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson" target=_blank><code>package.json</code> documentation</a> for further information.<br>' +
                    'A good reference for your <code>package.json</code> file is always the latest version of  <a href="https://github.com/TryGhost/Casper/blob/master/package.json" target=_blank>Casper</a>.'
     },
     'GS010-PJ-NAME-LC': {
@@ -335,51 +335,51 @@ rules = {
         rule: '<code>package.json</code> property <code>"name"</code> must be lowercase',
         details: 'The property <code>"name"</code> in your <code>package.json</code> file must be lowercase.<br>' +
                    'Good examples are: <code>"my-theme"</code> or <code>"theme"</code> rather than <code>"My Theme"</code> or <code>"Theme"</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--name-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--name-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-NAME-HY': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"name"</code> must be hyphenated',
         details: 'The property <code>"name"</code> in your <code>package.json</code> file must be hyphenated.<br>' +
                    'Please use <code>"my-theme"</code> rather than <code>"My Theme"</code> or <code>"my theme"</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--name-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--name-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-NAME-REQ': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"name"</code> is required',
         details: 'Please add the property <code>"name"</code> to your <code>package.json</code>. E.g. <code>{"name": "my-theme"}</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
     },
     'GS010-PJ-VERSION-SEM': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"version"</code> must be semver compliant',
         details: 'The property <code>"version"</code> in your <code>package.json</code> file must be semver compliant. E.g. <code>{"version": "1.0.0"}</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--version-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--version-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-VERSION-REQ': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"version"</code> is required',
         details: 'Please add the property <code>"version"</code> to your <code>package.json</code>. E.g. <code>{"version": "1.0.0"}</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
     },
     'GS010-PJ-AUT-EM-VAL': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"author.email"</code> must be valid',
         details: 'The property <code>"author.email"</code> in your <code>package.json</code> file must a valid email. E.g. <code>{"author": {"email": "hello@example.com"}}</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--author-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--author-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-CONF-PPP': {
         level: 'recommendation',
         rule: '<code>package.json</code> property <code>"config.posts_per_page"</code> is recommended. Otherwise, it falls back to 5',
         details: 'Please add <code>"posts_per_page"</code> to your <code>package.json</code>. E.g. <code>{"config": { "posts_per_page": 5}}</code>.<br>' +
                    'If no <code>"posts_per_page"</code> property is provided, Ghost will use its default setting of 5 posts per page.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--config-posts_per_page-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--config-posts_per_page-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-CONF-PPP-INT': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"config.posts_per_page"</code> must be a number above 0',
         details: 'The property <code>"config.posts_per_page"</code> in your <code>package.json</code> file must be a number greater than zero. E.g. <code>{"config": { "posts_per_page": 5}}</code>.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson#section--config-posts_per_page-" target=_blank><code>package.json</code> documentation</a> for further information.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson#section--config-posts_per_page-" target=_blank><code>package.json</code> documentation</a> for further information.'
     },
     'GS010-PJ-AUT-EM-REQ': {
         level: 'error',
@@ -388,54 +388,54 @@ rules = {
                    'The email is required so that themes which are distributed (either free or paid) have a method of contacting the author so users can get support and more importantly so that ' +
                    'Ghost can reach out about breaking changes and security updates.<br>' +
                    'The <code>package.json</code> file is <strong>NOT</strong> accessible when uploaded to a blog so if the theme is only uploaded to a single blog, no one will see this email address.<br>' +
-                   'Check the <a href="https://themes.ghost.org/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
+                   'Check the <a href="https://themes.ghost.org/v1.25.0/docs/packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.'
     },
     'GS020-INDEX-REQ': {
         level: 'error',
         rule: 'A template file called <code>index.hbs</code> must be present',
         fatal: true,
         details: 'Your theme must have a template file called <code>index.hbs</code>.<br>' +
-                   'Read <a href="https://themes.ghost.org/docs/templates" target=_blank>here</a> more about the required template structure and <code>index.hbs</code> in <a href="https://themes.ghost.org/docs/templates#section-index-hbs" target=_blank>particular</a>.'
+                   'Read <a href="https://themes.ghost.org/v1.25.0/docs/templates" target=_blank>here</a> more about the required template structure and <code>index.hbs</code> in <a href="https://themes.ghost.org/v1.25.0/docs/templates#section-index-hbs" target=_blank>particular</a>.'
     },
     'GS020-POST-REQ': {
         level: 'error',
         rule: 'A template file called <code>post.hbs</code> must be present',
         fatal: true,
         details: 'Your theme must have a template file called <code>index.hbs</code>.<br>' +
-                   'Read <a href="https://themes.ghost.org/docs/templates" target=_blank>here</a> more about the required template structure and <code>post.hbs</code> in <a href="https://themes.ghost.org/docs/templates#section-post-hbs" target=_blank>particular</a>.'
+                   'Read <a href="https://themes.ghost.org/v1.25.0/docs/templates" target=_blank>here</a> more about the required template structure and <code>post.hbs</code> in <a href="https://themes.ghost.org/v1.25.0/docs/templates#section-post-hbs" target=_blank>particular</a>.'
     },
     'GS020-DEF-REC': {
         level: 'recommendation',
         rule: 'Provide a default layout template called default.hbs',
         details: 'It is recommended that your theme has a template file called <code>default.hbs</code>.<br>' +
-                   'Read <a href="https://themes.ghost.org/docs/templates" target=_blank>here</a> more about the recommended template structure and <code>default.hbs</code> in <a href="https://themes.ghost.org/docs/templates#section-default-hbs" target=_blank>particular</a>.'
+                   'Read <a href="https://themes.ghost.org/v1.25.0/docs/templates" target=_blank>here</a> more about the recommended template structure and <code>default.hbs</code> in <a href="https://themes.ghost.org/v1.25.0/docs/templates#section-default-hbs" target=_blank>particular</a>.'
     },
     'GS030-ASSET-REQ': {
         level: 'warning',
         rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
         details: 'The listed files should be included using the <code>{{asset}}</code> helper.<br>' +
-                   'For more information, please see the <a href="https://themes.ghost.org/docs/asset" target=_blank><code>{{asset}}</code> helper documentation</a>.'
+                   'For more information, please see the <a href="https://themes.ghost.org/v1.25.0/docs/asset" target=_blank><code>{{asset}}</code> helper documentation</a>.'
     },
     'GS030-ASSET-SYM': {
         level: 'error',
         rule: 'Symlinks in themes are not allowed',
         fatal: true,
         details: 'Symbolic links in themes are not allowed. Please use the <code>{{asset}}</code> helper.<br>' +
-                   'For more information, please see the <a href="https://themes.ghost.org/docs/asset" target=_blank><code>{{asset}}</code> helper documentation</a>.'
+                   'For more information, please see the <a href="https://themes.ghost.org/v1.25.0/docs/asset" target=_blank><code>{{asset}}</code> helper documentation</a>.'
     },
     'GS040-GH-REQ': {
         level: 'warning',
         rule: 'The helper <code>{{ghost_head}}</code> should be present',
         details: 'The <code>{{ghost_head}}</code> helper should be present in your theme. It outputs many useful things, such as <a href="https://help.ghost.org/hc/en-us/articles/223403488-Code-Injection" target=_blank>"code injection" scripts</a>, structured data, canonical links, meta description etc.<br>' +
                    'The helper belongs just before the <code></head></code> tag in your <code>default.hbs</code> template.<br>' +
-                   'For more details, please see the <a href="https://themes.ghost.org/docs/ghost_head" target=_blank><code>{{ghost_head}}</code> helper documentation</a>.'
+                   'For more details, please see the <a href="https://themes.ghost.org/v1.25.0/docs/ghost_head" target=_blank><code>{{ghost_head}}</code> helper documentation</a>.'
     },
     'GS040-GF-REQ': {
         level: 'warning',
         rule: 'The helper <code>{{ghost_foot}}</code> should be present',
         details: 'The <code>{{ghost_foot}}</code> helper should be present in your theme. It outputs scripts as saved in <a href="https://help.ghost.org/hc/en-us/articles/223403488-Code-Injection" target=_blank>"code injection" scripts</a>.<br>' +
                    'The helper belongs just before the <code></body></code> tag in your <code>default.hbs</code> template.<br>' +
-                   'For more details, please see the <a href="https://themes.ghost.org/docs/ghost_foot" target=_blank><code>{{ghost_foot}}</code> helper documentation</a>.'
+                   'For more details, please see the <a href="https://themes.ghost.org/v1.25.0/docs/ghost_foot" target=_blank><code>{{ghost_foot}}</code> helper documentation</a>.'
     }
 };
 


### PR DESCRIPTION
closes #117

- replaced https://themes.ghost.org/docs/ with https://themes.ghost.org/v1.25.0/docs/