### PR TITLE
Output the major version that was checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ To run a local zip file through the checks:
 
 `gscan /path/to/theme.zip -z`
 
+You can also pass a version. Currently supported is `--v1` or `-1`, which will check the theme
+for 1.0.0 requirements. By default, GScan will always check for the latest version:
+
+`gscan /path/to/theme.zip -z1`
+
+or
+
+`gscan /path/to/theme/directory --v1`
+
 ### 3. Lib usage
 
 Install using yarn/npm and then:
@@ -34,6 +43,11 @@ var gscan = require('gscan');
 
 gscan.checkZip({
     path: 'path-to-zip',
+    // if you need to check the theme for a different
+    // major Ghost version, you can pass it. Currently
+    // v1, which is Ghost 1.0 is supported. Default is
+    // the latest Ghost version 2.0:
+    // checkVersion: 'v1',
     name: 'my-theme'
 }).then(function (result) {
     console.log(result);

--- a/app/tpl/result.hbs
+++ b/app/tpl/result.hbs
@@ -15,6 +15,10 @@
 
     <div class="inner report-body">
         <div class="results report-section">
+            {{!-- TODO: make this pretty --}}
+            <div>
+                <p>Result for version {{checkedVersion}}:</p>
+            </div>
             {{#if results.error}}
                 <section class="level-group">
                     <header class="level-group-header">

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-var pkgJson = require('../package.json'),
-    program = require('commander'),
-    _ = require('lodash'),
-    chalk = require('chalk'),
-    gscan = require('../lib'),
+const pkgJson = require('../package.json');
+const program = require('commander');
+const _ = require('lodash');
+const chalk = require('chalk');
+const gscan = require('../lib');
 
-    options = {},
-    themePath = '',
-    levels;
+const options = {};
+let themePath = '';
+let levels;
 
 program
     .version(pkgJson.version)
@@ -37,7 +37,7 @@ function outputResult(result) {
 function outputResults(theme, options) {
     theme = gscan.format(theme, options);
 
-    console.log(chalk.bold.underline('\nRule Report:'));
+    console.log(chalk.bold.underline(`\nRule Report for v${theme.checkedVersion}:`));
 
     if (!_.isEmpty(theme.results.error)) {
         console.log(chalk.red.bold.underline('\n! Must fix:'));

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const requireDir = require('require-dir');
 const readTheme = require('./read-theme');
+const versions = require('./utils').versions;
 
 const checks = requireDir('./checks');
 
@@ -16,9 +17,13 @@ const checks = requireDir('./checks');
  */
 const checker = function checkAll(themePath, options) {
     options = options || {};
+    const passedVersion = _.get(options, 'checkVersion', 'latest');
 
     return readTheme(themePath)
         .then(function (theme) {
+            // set the major version to check
+            theme.checkedVersion = versions[passedVersion].major;
+            
             return Promise.reduce(_.values(checks), function (theme, check) {
                 return check(theme, options, themePath);
             }, theme);


### PR DESCRIPTION
refs #116
needs #127

- uses the versions util to fetch the major version and pass it along our `theme` object
- outputs the tested version for CLI and App usage
- for module usage, GScan returns a `checkedVersion` property with the major version that it was checked for
- updated README to include version usage