### PR TITLE
✨ Added ability to sort by files

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -71,7 +71,15 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
         failed.push(packageJSONValidationRules.authorEmailIsValid);
     }
 
-    _.extend(theme.results.fail, _private.getFailedRules(failed));
+    const failedRules = _private.getFailedRules(failed);
+    _.each(failedRules, (rule, key) => {
+        theme.results.fail[key] = {};
+        theme.results.fail[key].failures = [
+            {
+                ref: 'package.json'
+            }
+        ];
+    });
 
     // add intersection as passed
     theme.results.pass = theme.results.pass.concat(_.xor(failed, _.values(_.omit(packageJSONValidationRules, passedRulesToOmit))));
@@ -99,7 +107,17 @@ module.exports = function checkPackageJSON(theme, options) {
 
     // CASE: package.json must be present (if not, all validation rules fail)
     if (!_.some(theme.files, {file: packageJSONFile})) {
-        _.extend(theme.results.fail, _private.getFailedRules(_.values(_.omit(packageJSONValidationRules, _.keys(packageJSONConditionalRules)))));
+        const rules = _private.getFailedRules(_.values(_.omit(packageJSONValidationRules, _.keys(packageJSONConditionalRules))));
+
+        _.each(rules, (rule, key) => {
+            theme.results.fail[key] = {};
+            theme.results.fail[key].failures = [
+                {
+                    ref: 'package.json'
+                }
+            ];
+        });
+
         return theme;
     }
 

--- a/lib/checks/020-theme-structure.js
+++ b/lib/checks/020-theme-structure.js
@@ -26,7 +26,6 @@ const latestRulesToCheck = [];
 checkThemeStructure = function checkThemeStructure(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
     const ruleSet = spec.get([checkVersion]);
-    
     const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
 
     _.each(rulesToCheck, function (ruleCode) {
@@ -39,7 +38,13 @@ checkThemeStructure = function checkThemeStructure(theme, options) {
 
         if (!_.some(theme.files, {file: check.path})) {
             // file doesn't exist
-            theme.results.fail[ruleCode] = {};
+            theme.results.fail[ruleCode] = {
+                failures: [
+                    {
+                        ref: check.path
+                    }
+                ]
+            };
         } else {
             theme.results.pass.push(ruleCode);
         }

--- a/lib/checks/030-assets.js
+++ b/lib/checks/030-assets.js
@@ -13,13 +13,13 @@ checkAssets = function checkAssets(theme, options, themePath) {
     let ruleToCheck = 'GS030-ASSET-REQ';
     let failures = [];
     let defaultHbs = _.filter(theme.files, {file: 'default.hbs'});
-    let assetMatch; 
+    let assetMatch;
     let stats;
 
     if (!_.isEmpty(defaultHbs)) {
         defaultHbs = defaultHbs[0];
         while ((assetMatch = ruleSet.rules[ruleToCheck].regex.exec(defaultHbs.content)) !== null) {
-            failures.push({ref: assetMatch[2]});
+            failures.push({ref: 'default.hbs', message: `${assetMatch[2]}`});
         }
     }
 

--- a/lib/checks/040-ghost-head-foot.js
+++ b/lib/checks/040-ghost-head-foot.js
@@ -11,7 +11,6 @@ const latestRulesToCheck = [];
 checkGhostHeadFoot = function checkGhostHeadFoot(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
     const ruleSet = spec.get([checkVersion]);
-    
     const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
 
     _.each(rulesToCheck, function (ruleCode) {
@@ -23,7 +22,11 @@ checkGhostHeadFoot = function checkGhostHeadFoot(theme, options) {
         }
 
         if (!theme.helpers || !theme.helpers.hasOwnProperty(check.helper)) {
-            theme.results.fail[ruleCode] = {};
+            theme.results.fail[ruleCode] = {
+                failures: [{
+                    ref: 'default.hbs'
+                }]
+            };
         } else {
             theme.results.pass.push(ruleCode);
         }

--- a/lib/format.js
+++ b/lib/format.js
@@ -31,8 +31,8 @@ calcScore = function calcScore(results, stats) {
 /**
  * TODO: This needs cleaning up, a lot
  */
-format = function format(theme, options) {
-    options = _.extend({onlyFatalErrors: false}, options);
+format = function format(theme, options = {}) {
+    options = _.extend({onlyFatalErrors: false, sortByFiles: false}, options);
     const checkVersion = _.get(options, 'checkVersion', 'latest');
     const ruleSet = spec.get([checkVersion]);
 
@@ -67,7 +67,6 @@ format = function format(theme, options) {
 
     _.each(theme.results.pass, function (code, index) {
         const rule = ruleSet.rules[code];
-        
         theme.results.pass[index] = _.extend({}, rule, {code: code});
         stats[rule.level] += 1;
         processedCodes.push(code);
@@ -80,8 +79,78 @@ format = function format(theme, options) {
     theme.results.score = calcScore(theme.results, stats);
     theme.results.hasFatalErrors = hasFatalErrors;
 
-    // SORT errors!
-    theme.results.error = _.orderBy(theme.results.error, 'fatal', 'desc');
+    // CASE 1: sort by files (@TODO: sort by passed rules is not possible, because we don't push the file reference)
+    // CASE 2: (default): sort by rules
+    if (options.sortByFiles) {
+        const recommendationsByFile = {};
+        const errorsByFile = {};
+        const warningsByFile = {};
+
+        theme.results.error.forEach((error) => {
+            const failures = error.failures;
+
+            if (!failures || !failures.length) {
+                return;
+            }
+
+            failures.forEach((failure) => {
+                if (!errorsByFile.hasOwnProperty(failure.ref)) {
+                    errorsByFile[failure.ref] = [];
+                }
+
+                errorsByFile[failure.ref].push(error);
+            });
+        });
+
+        theme.results.warning.forEach((warning) => {
+            const failures = warning.failures;
+
+            if (!failures || !failures.length) {
+                return;
+            }
+
+            failures.forEach((failure) => {
+                if (!warningsByFile.hasOwnProperty(failure.ref)) {
+                    warningsByFile[failure.ref] = [];
+                }
+
+                warningsByFile[failure.ref].push(warning);
+            });
+        });
+
+        theme.results.recommendation.forEach((passed) => {
+            const failures = passed.failures;
+
+            if (!failures || !failures.length) {
+                return;
+            }
+
+            failures.forEach((failure) => {
+                if (!recommendationsByFile.hasOwnProperty(failure.ref)) {
+                    recommendationsByFile[failure.ref] = [];
+                }
+
+                recommendationsByFile[failure.ref].push(passed);
+            });
+        });
+
+        theme.results.recommendation = {
+            all: theme.results.recommendation,
+            byFiles: recommendationsByFile
+        };
+
+        theme.results.error = {
+            all: theme.results.error,
+            byFiles: errorsByFile
+        };
+
+        theme.results.warning = {
+            all: theme.results.warning,
+            byFiles: warningsByFile
+        };
+    } else {
+        theme.results.error = _.orderBy(theme.results.error, 'fatal', 'desc');
+    }
 
     return theme;
 };

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -26,6 +26,7 @@ describe('010: package.json', function () {
             );
 
             output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
+            output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
             done();
         }).catch(done);
     });
@@ -51,6 +52,7 @@ describe('010: package.json', function () {
             );
 
             output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
+            output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
             done();
         }).catch(done);
     });
@@ -126,6 +128,9 @@ describe('010: package.json', function () {
                 'GS010-PJ-AUT-EM-VAL',
                 'GS010-PJ-CONF-PPP-INT'
             );
+
+            theme.results.fail['GS010-PJ-NAME-LC'].failures[0].ref.should.eql('package.json');
+
             done();
         }).catch(done);
     });

--- a/test/020-theme-structure.test.js
+++ b/test/020-theme-structure.test.js
@@ -18,6 +18,10 @@ describe('Theme structure', function () {
             output.results.fail['GS020-POST-REQ'].should.be.a.ValidFailObject();
             output.results.fail['GS020-DEF-REC'].should.be.a.ValidFailObject();
 
+            output.results.fail['GS020-INDEX-REQ'].failures[0].ref.should.eql('index.hbs');
+            output.results.fail['GS020-POST-REQ'].failures[0].ref.should.eql('post.hbs');
+            output.results.fail['GS020-DEF-REC'].failures[0].ref.should.eql('default.hbs');
+
             done();
         });
     });

--- a/test/030-assets.test.js
+++ b/test/030-assets.test.js
@@ -16,8 +16,9 @@ describe('Assets', function () {
 
             output.results.fail['GS030-ASSET-REQ'].should.be.a.ValidFailObject();
             output.results.fail['GS030-ASSET-REQ'].failures.should.be.an.Array().with.lengthOf(1);
-            output.results.fail['GS030-ASSET-REQ'].failures[0].should.have.keys('ref');
-            output.results.fail['GS030-ASSET-REQ'].failures[0].ref.should.eql('/assets/css/style.css');
+            output.results.fail['GS030-ASSET-REQ'].failures[0].should.have.keys('ref', 'message');
+            output.results.fail['GS030-ASSET-REQ'].failures[0].ref.should.eql('default.hbs');
+            output.results.fail['GS030-ASSET-REQ'].failures[0].message.should.eql('/assets/css/style.css');
 
             done();
         }).catch(done);

--- a/test/040-ghost-head-foot.test.js
+++ b/test/040-ghost-head-foot.test.js
@@ -16,6 +16,9 @@ describe('Ghost head & foot', function () {
             output.results.fail['GS040-GH-REQ'].should.be.a.ValidFailObject();
             output.results.fail['GS040-GF-REQ'].should.be.a.ValidFailObject();
 
+            output.results.fail['GS040-GH-REQ'].failures[0].ref.should.eql('default.hbs');
+            output.results.fail['GS040-GF-REQ'].failures[0].ref.should.eql('default.hbs');
+
             done();
         }).catch(done);
     });

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -398,6 +398,7 @@ describe('format', function () {
         checker(themePath('005-compile/invalid')).then((theme) => {
             theme = format(theme);
 
+            theme.results.error.length.should.eql(10);
             theme.results.error[0].fatal.should.eql(true);
             theme.results.error[1].fatal.should.eql(false);
             theme.results.error[8].fatal.should.eql(false);
@@ -416,6 +417,53 @@ describe('format', function () {
             theme.results.error[8].fatal.should.eql(false);
             theme.results.error[9].fatal.should.eql(false);
             theme.results.error[10].fatal.should.eql(false);
+
+            done();
+        });
+    });
+
+    it('sort by files', function (done) {
+        checker(themePath('005-compile/invalid')).then((theme) => {
+            theme = format(theme, {sortByFiles: true});
+
+            theme.results.hasFatalErrors.should.be.true();
+
+            theme.results.recommendation.all.length.should.eql(1);
+            theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+
+            theme.results.warning.all.length.should.eql(2);
+            theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
+
+            theme.results.error.all.length.should.eql(10);
+
+            // 1 rule has file references
+            theme.results.error.byFiles['author.hbs'].length.should.eql(1);
+            theme.results.error.byFiles['page.hbs'].length.should.eql(1);
+            theme.results.error.byFiles['post.hbs'].length.should.eql(1);
+            theme.results.error.byFiles['index.hbs'].length.should.eql(1);
+            theme.results.error.byFiles['package.json'].length.should.eql(9);
+
+            done();
+        });
+    });
+
+    it('sort by files', function (done) {
+        checker(themePath('001-deprecations/invalid')).then((theme) => {
+            theme = format(theme, {sortByFiles: true});
+
+            theme.results.hasFatalErrors.should.be.true();
+
+            theme.results.recommendation.all.length.should.eql(1);
+            theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+
+            theme.results.error.all.length.should.eql(36);
+            theme.results.warning.all.length.should.eql(0);
+
+            theme.results.error.byFiles['assets/my.css'].length.should.eql(5);
+            theme.results.error.byFiles['default.hbs'].length.should.eql(6);
+            theme.results.error.byFiles['post.hbs'].length.should.eql(17);
+            theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(4);
+            theme.results.error.byFiles['index.hbs'].length.should.eql(7);
 
             done();
         });


### PR DESCRIPTION
refs #122

- gscan.format accepts a new flag to return a different format
  - sort by errors & warnings files

**This PR does not sort the passed rules by files, because we never push the reference and this is too much work now**