### PR TITLE
Detect invalid handlebar expressions in translations (#133)

### DIFF
--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -10,6 +10,39 @@ checkTemplatesCompile = function checkTemplatesCompile(theme) {
         failures = [],
         missingHelper;
 
+    var tryCompile = function (themeFile) {
+        var compiled;
+        try {
+            // When we read the theme, we precompile, here we compile with registered partials and helpers
+            // Which will let us detect any missing partials, helpers or parse errors
+            compiled = localHbs.handlebars.compile(themeFile.content, {
+                knownHelpers: _.zipObject(spec.knownHelpers, _.map(spec.knownHelpers, function () {
+                    return true;
+                })),
+                knownHelpersOnly: true
+            });
+
+            // NOTE: fakeData does not resolve finding unknown helpers in context objects!
+            compiled(fakeData(themeFile));
+        } catch (error) {
+            // CASE: transform ugly error message from hbs to the known error message: Missing helper: "X"
+            if (error.message.match(/you specified knownhelpersOnly/gi)) {
+                try {
+                    missingHelper = error.message.match(/but\sused\sthe\sunknown\shelper\s(.*)\s-/)[1];
+                } catch (err) {
+                    missingHelper = 'unknown helper name';
+                }
+
+                error.message = 'Missing helper: "' + missingHelper + '"';
+            }
+
+            failures.push({
+                ref: themeFile.file,
+                message: error.message
+            });
+        }
+    };
+
     _.each(theme.partials, function (partial) {
         // ensures partials work when running gscan on windows
         var partialName = partial.split('\\').join('/');
@@ -30,40 +63,15 @@ checkTemplatesCompile = function checkTemplatesCompile(theme) {
     });
 
     _.each(theme.files, function (themeFile) {
-        var templateTest = themeFile.file.match(/^[^/]+.hbs$/),
-            compiled;
+        var templateTest = themeFile.file.match(/^[^/]+.hbs$/);
+
+        localHbs.handlebars.registerHelper('t', function (template) {
+            tryCompile({content: template, file: themeFile.file});
+        });
 
         // If this is a main template, test compiling it properly
         if (templateTest) {
-            try {
-                // When we read the theme, we precompile, here we compile with registered partials and helpers
-                // Which will let us detect any missing partials, helpers or parse errors
-                compiled = localHbs.handlebars.compile(themeFile.content, {
-                    knownHelpers: _.zipObject(spec.knownHelpers, _.map(spec.knownHelpers, function () {
-                        return true;
-                    })),
-                    knownHelpersOnly: true
-                });
-
-                // NOTE: fakeData does not resolve finding unknown helpers in context objects!
-                compiled(fakeData(themeFile));
-            } catch (error) {
-                // CASE: transform ugly error message from hbs to the known error message: Missing helper: "X"
-                if (error.message.match(/you specified knownhelpersOnly/gi)) {
-                    try {
-                        missingHelper = error.message.match(/but\sused\sthe\sunknown\shelper\s(.*)\s-/)[1];
-                    } catch (err) {
-                        missingHelper = 'unknown helper name';
-                    }
-
-                    error.message = 'Missing helper: "' + missingHelper + '"';
-                }
-
-                failures.push({
-                    ref: themeFile.file,
-                    message: error.message
-                });
-            }
+            tryCompile(themeFile);
         }
     });
 

--- a/test/005-template-compile.test.js
+++ b/test/005-template-compile.test.js
@@ -66,4 +66,30 @@ describe('Template compile', function () {
             done();
         }).catch(done);
     });
+
+    it('should output empty array for a theme with valid translate', function (done) {
+        utils.testCheck(thisCheck, '005-compile/validTranslate').then(function (output) {
+            output.should.be.a.ValidThemeObject();
+
+            output.results.fail.should.be.an.Object().which.is.empty();
+
+            output.results.pass.should.be.an.Array().with.lengthOf(1);
+            output.results.pass.should.containEql('GS005-TPL-ERR');
+
+            done();
+        }).catch(done);
+    });
+
+    it('should output error for a theme with an invalid translate', function (done) {
+        utils.testCheck(thisCheck, '005-compile/invalidTranslate').then(function (output) {
+            output.should.be.a.ValidThemeObject();
+
+            output.results.pass.should.be.an.Object().which.is.empty();
+
+            output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
+            output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
+
+            done();
+        }).catch(done);
+    });
 });

--- a/test/fixtures/themes/005-compile/invalidTranslate/default.hbs
+++ b/test/fixtures/themes/005-compile/invalidTranslate/default.hbs
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="{{asset "css/style.css"}}">
+    {{ghost_head}}
+</head>
+<body>
+
+    <h1>{{@blog.title}}</h1>
+    {{ghost_foot}}
+
+    {{t "page {{page}" page=page}}
+</body>
+</html>

--- a/test/fixtures/themes/005-compile/validTranslate/default.hbs
+++ b/test/fixtures/themes/005-compile/validTranslate/default.hbs
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="{{asset "css/style.css"}}">
+    {{ghost_head}}
+</head>
+<body>
+
+    <h1>{{@blog.title}}</h1>
+    {{ghost_foot}}
+
+    {{t "page {{page}}" page=page}}
+</body>
+</html>


### PR DESCRIPTION
Reports an invalid handlebar expression in translation as compile error.

I could not find a way to return the correct line inside the template-file.
The handlebar-helpers do not seems to be aware of this.