### PR TITLE
✨Added keyword check for `ghost-theme`

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -25,50 +25,63 @@ const v1PackageJSONValidationRules = _.extend({
 
 const latestPackageJSONConditionalRules = {};
 
-const latestPackageJSONValidationRules = _.extend({}, latestPackageJSONConditionalRules);
+const latestPackageJSONValidationRules = _.extend({},
+    {isMarkedGhostTheme: 'GS010-PJ-KEYWORDS'},
+    latestPackageJSONConditionalRules);
 
 _private.validatePackageJSONFields = function validatePackageJSONFields(packageJSON, theme, packageJSONValidationRules) {
     let failed = [];
     const passedRulesToOmit = [];
 
+    // Only add this rule to the failed list if it's defined in packageJSONValidationRules
+    function markFailed(rule) {
+        if (packageJSONValidationRules[rule]) {
+            failed.push(packageJSONValidationRules[rule]);
+        }
+    }
+
     if (!packageJSON.name) {
-        failed.push(packageJSONValidationRules.nameIsRequired);
-        failed.push(packageJSONValidationRules.nameIsLowerCase);
-        failed.push(packageJSONValidationRules.nameIsHyphenated);
+        markFailed('nameIsRequired');
+        markFailed('nameIsLowerCase');
+        markFailed('nameIsHyphenated');
     }
 
     if (!packageJSON.version) {
-        failed.push(packageJSONValidationRules.versionIsRequired);
-        failed.push(packageJSONValidationRules.versionIsSemverCompliant);
+        markFailed('versionIsRequired');
+        markFailed('versionIsSemverCompliant');
     }
 
     if (!packageJSON.config || _.isNil(packageJSON.config.posts_per_page)) {
-        failed.push(packageJSONValidationRules.configPPPIsRequired);
+        markFailed('configPPPIsRequired');
         passedRulesToOmit.push('configPPIsInteger');
     } else if (!_.isNumber(packageJSON.config.posts_per_page) || packageJSON.config.posts_per_page < 1) {
         failed = _.without(failed, packageJSONValidationRules.configPPPIsRequired);
-        failed.push(packageJSONValidationRules.configPPIsInteger);
+        markFailed('configPPIsInteger');
     }
 
     if (!packageJSON.author || !packageJSON.author.email) {
-        failed.push(packageJSONValidationRules.authorEmailIsRequired);
-        failed.push(packageJSONValidationRules.authorEmailIsValid);
+        markFailed('authorEmailIsRequired');
+        markFailed('authorEmailIsValid');
+    }
+
+    if (!packageJSON.keywords || !_.isArray(packageJSON.keywords) || !_.includes(packageJSON.keywords, 'ghost-theme')) {
+        markFailed('isMarkedGhostTheme');
     }
 
     if (packageJSON.name && packageJSON.name !== packageJSON.name.toLowerCase()) {
-        failed.push(packageJSONValidationRules.nameIsLowerCase);
+        markFailed('nameIsLowerCase');
     }
 
     if (packageJSON.name && !packageJSON.name.match(/^[a-z0-9]+(-?[a-z0-9]+)*$/gi)) {
-        failed.push(packageJSONValidationRules.nameIsHyphenated);
+        markFailed('nameIsHyphenated');
     }
 
     if (packageJSON.version && !semver.valid(packageJSON.version)) {
-        failed.push(packageJSONValidationRules.versionIsSemverCompliant);
+        markFailed('versionIsSemverCompliant');
     }
 
     if (packageJSON.author && packageJSON.author.email && !validator.isEmail(packageJSON.author.email)) {
-        failed.push(packageJSONValidationRules.authorEmailIsValid);
+        markFailed('authorEmailIsValid');
     }
 
     const failedRules = _private.getFailedRules(failed);

--- a/lib/specs/latest.js
+++ b/lib/specs/latest.js
@@ -484,6 +484,12 @@ rules = {
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
         regex: /{{\s*?#if\s*?(?:post\.)(?:author|primary_author|authors\.\[[0-9]+\])\.(image)\s*?}}/g,
         helper: '{{#if post.primary_author.image}}'
+    },
+    'GS010-PJ-KEYWORDS': {
+        level: 'warning',
+        rule: '<code>package.json</code> property <code>keywords</code> should contain <code>ghost-theme</code>',
+        details: `The property <code>keywords</code> in your <code>package.json</code> file must contain <code>ghost-theme</code>. E.g. <code>{"keywords": ["ghost-theme"]}</code>.<br>
+        Check the <a href="${docsBaseUrl}packagejson#section--keywords-" target=_blank><code>package.json</code> documentation</a> for further information.`
     }
 };
 

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -3,207 +3,288 @@ var should = require('should'), // eslint-disable-line no-unused-vars
     thisCheck = require('../lib/checks/010-package-json');
 
 describe('010 package.json', function () {
-    const options = {checkVersion: 'v1'};
+    describe('v1:', function () {
+        const options = {checkVersion: 'v1'};
 
-    it('should output error for missing package.json', function (done) {
-        utils.testCheck(thisCheck, 'is-empty', options).then(function (output) {
-            output.should.be.a.ValidThemeObject();
+        it('should output error for missing package.json', function (done) {
+            utils.testCheck(thisCheck, 'is-empty', options).then(function (output) {
+                output.should.be.a.ValidThemeObject();
 
-            output.results.pass.should.be.an.Array().with.lengthOf(0);
+                output.results.pass.should.be.an.Array().with.lengthOf(0);
 
-            // package.json not found, can't parse and all fields are missing + invalid
-            output.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            );
+                // package.json not found, can't parse and all fields are missing + invalid
+                output.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                );
 
-            output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
-            output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
-            done();
-        }).catch(done);
+                output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
+                output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
+                done();
+            }).catch(done);
+        });
+
+        it('should output error for missing package.json', function (done) {
+            utils.testCheck(thisCheck, 'is-empty', options).then(function (output) {
+                output.should.be.a.ValidThemeObject();
+
+                output.results.pass.should.be.an.Array().with.lengthOf(0);
+
+                // package.json not found, can't parse and all fields are missing + invalid
+                output.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                );
+
+                output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
+                output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
+                done();
+            }).catch(done);
+        });
+
+        it('should output error for invalid package.json (parsing)', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/parse-error', options).then(function (output) {
+                output.should.be.a.ValidThemeObject();
+
+                output.results.pass.should.be.an.Array().with.lengthOf(0);
+
+                // can't parse package.json and all fields are missing + invalid
+                output.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                );
+
+                output.results.fail['GS010-PJ-PARSE'].should.be.a.ValidFailObject();
+                output.results.fail['GS010-PJ-PARSE'].failures.length.should.eql(1);
+                output.results.fail['GS010-PJ-PARSE'].failures[0].ref.should.eql('package.json');
+                output.results.fail['GS010-PJ-PARSE'].failures[0].message.should.containEql('Unexpected token');
+
+                done();
+            }).catch(done);
+        });
+
+        it('valid fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-valid', options).then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
+
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP',
+                    'GS010-PJ-CONF-PPP-INT'
+                ]);
+
+                theme.results.fail.should.be.an.Object().which.is.empty();
+                done();
+            }).catch(done);
+        });
+
+        it('invalid fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-invalid', options).then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
+
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                ]);
+
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-CONF-PPP-INT'
+                );
+
+                theme.results.fail['GS010-PJ-NAME-LC'].failures[0].ref.should.eql('package.json');
+
+                done();
+            }).catch(done);
+        });
+
+        it('missing fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-missing', options).then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
+
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE'
+                ]);
+
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-CONF-PPP',
+                    'GS010-PJ-AUT-EM-VAL'
+                );
+
+                done();
+            }).catch(done);
+        });
+
+        it('bad config (ppp: -3 > 0)', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/bad-config', options).then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
+
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                ]);
+
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-CONF-PPP-INT'
+                );
+                done();
+            }).catch(done);
+        });
+
+        it('bad config 2 (ppp: 0 > 0)', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/bad-config-2', options).then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
+
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                ]);
+
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-CONF-PPP-INT'
+                );
+                done();
+            }).catch(done);
+        });
     });
 
-    it('should output error for missing package.json', function (done) {
-        utils.testCheck(thisCheck, 'is-empty', options).then(function (output) {
-            output.should.be.a.ValidThemeObject();
+    describe('latest version:', function () {
+        it('valid fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-valid').then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
 
-            output.results.pass.should.be.an.Array().with.lengthOf(0);
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP',
+                    'GS010-PJ-CONF-PPP-INT',
+                    'GS010-PJ-KEYWORDS'
+                ]);
 
-            // package.json not found, can't parse and all fields are missing + invalid
-            output.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            );
+                theme.results.fail.should.be.an.Object().which.is.empty();
+                done();
+            }).catch(done);
+        });
 
-            output.results.fail['GS010-PJ-REQ'].should.be.a.ValidFailObject();
-            output.results.fail['GS010-PJ-REQ'].failures[0].ref.should.eql('package.json');
-            done();
-        }).catch(done);
-    });
+        it('invalid fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-invalid').then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
 
-    it('should output error for invalid package.json (parsing)', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/parse-error', options).then(function (output) {
-            output.should.be.a.ValidThemeObject();
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-CONF-PPP'
+                ]);
 
-            output.results.pass.should.be.an.Array().with.lengthOf(0);
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-CONF-PPP-INT',
+                    'GS010-PJ-KEYWORDS'
+                );
 
-            // can't parse package.json and all fields are missing + invalid
-            output.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            );
+                theme.results.fail['GS010-PJ-NAME-LC'].failures[0].ref.should.eql('package.json');
 
-            output.results.fail['GS010-PJ-PARSE'].should.be.a.ValidFailObject();
-            output.results.fail['GS010-PJ-PARSE'].failures.length.should.eql(1);
-            output.results.fail['GS010-PJ-PARSE'].failures[0].ref.should.eql('package.json');
-            output.results.fail['GS010-PJ-PARSE'].failures[0].message.should.containEql('Unexpected token');
+                done();
+            }).catch(done);
+        });
 
-            done();
-        }).catch(done);
-    });
+        it('missing fields', function (done) {
+            utils.testCheck(thisCheck, '010-packagejson/fields-are-missing').then(function (theme) {
+                theme.should.be.a.ValidThemeObject();
 
-    it('valid fields', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/fields-are-valid', options).then(function (theme) {
-            theme.should.be.a.ValidThemeObject();
+                theme.results.pass.should.eql([
+                    'GS010-PJ-REQ',
+                    'GS010-PJ-PARSE'
+                ]);
 
-            theme.results.pass.should.eql([
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP',
-                'GS010-PJ-CONF-PPP-INT'
-            ]);
+                theme.results.fail.should.be.an.Object().with.keys(
+                    'GS010-PJ-AUT-EM-REQ',
+                    'GS010-PJ-NAME-REQ',
+                    'GS010-PJ-VERSION-REQ',
+                    'GS010-PJ-NAME-LC',
+                    'GS010-PJ-NAME-HY',
+                    'GS010-PJ-VERSION-SEM',
+                    'GS010-PJ-CONF-PPP',
+                    'GS010-PJ-AUT-EM-VAL',
+                    'GS010-PJ-KEYWORDS'
+                );
 
-            theme.results.fail.should.be.an.Object().which.is.empty();
-            done();
-        }).catch(done);
-    });
-
-    it('invalid fields', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/fields-are-invalid', options).then(function (theme) {
-            theme.should.be.a.ValidThemeObject();
-
-            theme.results.pass.should.eql([
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            ]);
-
-            theme.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-CONF-PPP-INT'
-            );
-
-            theme.results.fail['GS010-PJ-NAME-LC'].failures[0].ref.should.eql('package.json');
-
-            done();
-        }).catch(done);
-    });
-
-    it('missing fields', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/fields-are-missing', options).then(function (theme) {
-            theme.should.be.a.ValidThemeObject();
-
-            theme.results.pass.should.eql([
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE'
-            ]);
-
-            theme.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-CONF-PPP',
-                'GS010-PJ-AUT-EM-VAL'
-            );
-
-            done();
-        }).catch(done);
-    });
-
-    it('bad config (ppp: -3 > 0)', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/bad-config', options).then(function (theme) {
-            theme.should.be.a.ValidThemeObject();
-
-            theme.results.pass.should.eql([
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            ]);
-
-            theme.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-CONF-PPP-INT'
-            );
-            done();
-        }).catch(done);
-    });
-
-    it('bad config 2 (ppp: 0 > 0)', function (done) {
-        utils.testCheck(thisCheck, '010-packagejson/bad-config-2', options).then(function (theme) {
-            theme.should.be.a.ValidThemeObject();
-
-            theme.results.pass.should.eql([
-                'GS010-PJ-REQ',
-                'GS010-PJ-PARSE',
-                'GS010-PJ-NAME-REQ',
-                'GS010-PJ-NAME-LC',
-                'GS010-PJ-NAME-HY',
-                'GS010-PJ-VERSION-SEM',
-                'GS010-PJ-VERSION-REQ',
-                'GS010-PJ-AUT-EM-VAL',
-                'GS010-PJ-AUT-EM-REQ',
-                'GS010-PJ-CONF-PPP'
-            ]);
-
-            theme.results.fail.should.be.an.Object().with.keys(
-                'GS010-PJ-CONF-PPP-INT'
-            );
-            done();
-        }).catch(done);
+                done();
+            }).catch(done);
+        });
     });
 });

--- a/test/fixtures/themes/010-packagejson/fields-are-invalid/package.json
+++ b/test/fixtures/themes/010-packagejson/fields-are-invalid/package.json
@@ -4,6 +4,7 @@
   "author": {
     "email": "something"
   },
+  "keywords": "ghost-theme",
   "config": {
     "posts_per_page": "something"
   }

--- a/test/fixtures/themes/010-packagejson/fields-are-valid/package.json
+++ b/test/fixtures/themes/010-packagejson/fields-are-valid/package.json
@@ -4,6 +4,11 @@
   "author": {
     "email": "theme@example.org"
   },
+  "keywords": [
+    "ghost",
+    "theme",
+    "ghost-theme"
+  ],
   "config": {
     "posts_per_page": 3
   }

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -336,6 +336,7 @@ describe('Checker', function () {
                 'GS010-PJ-AUT-EM-VAL',
                 'GS010-PJ-AUT-EM-REQ',
                 'GS010-PJ-CONF-PPP',
+                'GS010-PJ-KEYWORDS',
                 'GS020-INDEX-REQ',
                 'GS020-POST-REQ',
                 'GS020-DEF-REC',
@@ -434,7 +435,7 @@ describe('format', function () {
             theme.results.recommendation.all.length.should.eql(1);
             theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
-            theme.results.warning.all.length.should.eql(2);
+            theme.results.warning.all.length.should.eql(3);
             theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
 
             theme.results.error.all.length.should.eql(12);
@@ -460,7 +461,7 @@ describe('format', function () {
             theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
             theme.results.error.all.length.should.eql(80);
-            theme.results.warning.all.length.should.eql(1);
+            theme.results.warning.all.length.should.eql(2);
 
             theme.results.error.byFiles['assets/my.css'].length.should.eql(5);
             theme.results.error.byFiles['default.hbs'].length.should.eql(12);


### PR DESCRIPTION
closes #143 

This is being added as a warning in Ghost 2.0, and will be an error in Ghost 3.0


-----

~~Tests are failing unexpectedly saying that the new rule is present in the list of passes/fails when it should not be, e.g. for `checks for an older version if passed`~~

Tests fixed by https://github.com/TryGhost/gscan/commit/64e39ec344b26a771a080a42092c1fe2ffe64489 working on adding new tests for this change.

