### PR TITLE
Refactor checkers to fetch rules per name

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -2,99 +2,23 @@ const _ = require('lodash');
 const path = require('path');
 const fs = require('fs-extra');
 const spec = require('../specs');
-const debug = require('ghost-ignition').debug('checks:deprecations');
 
 let checkDeprecations;
 
-const v1RulesToCheck = [
-    'GS001-DEPR-PURL',
-    'GS001-DEPR-MD',
-    'GS001-DEPR-IMG',
-    'GS001-DEPR-COV',
-    'GS001-DEPR-AIMG',
-    'GS001-DEPR-PIMG',
-    'GS001-DEPR-BC',
-    'GS001-DEPR-AC',
-    'GS001-DEPR-TIMG',
-    'GS001-DEPR-TSIMG',
-    'GS001-DEPR-PAIMG',
-    'GS001-DEPR-PAC',
-    'GS001-DEPR-PTIMG',
-    'GS001-DEPR-CON-IMG',
-    'GS001-DEPR-CON-COV',
-    'GS001-DEPR-CON-BC',
-    'GS001-DEPR-CON-AC',
-    'GS001-DEPR-CON-AIMG',
-    'GS001-DEPR-CON-PAC',
-    'GS001-DEPR-CON-PAIMG',
-    'GS001-DEPR-CON-TIMG',
-    'GS001-DEPR-CON-PTIMG',
-    'GS001-DEPR-CON-TSIMG',
-    'GS001-DEPR-PPP',
-    'GS001-DEPR-C0H',
-    'GS001-DEPR-CSS-AT',
-    'GS001-DEPR-CSS-PA',
-    'GS001-DEPR-CSS-PATS'
-];
-
-const latestRulesToCheck = [
-    'GS001-DEPR-CSS-KGMD',
-    'GS001-DEPR-AUTH-INCL',
-    'GS001-DEPR-AUTH-FIELD',
-    'GS001-DEPR-AUTH-FILT',
-    'GS001-DEPR-AUTHBL',
-    'GS001-DEPR-CON-AUTH',
-    'GS001-DEPR-CON-PAUTH',
-    'GS001-DEPR-AUTH',
-    'GS001-DEPR-AUTH-ID',
-    'GS001-DEPR-AUTH-SLUG',
-    'GS001-DEPR-AUTH-MAIL',
-    'GS001-DEPR-AUTH-MT',
-    'GS001-DEPR-AUTH-MD',
-    'GS001-DEPR-AUTH-NAME',
-    'GS001-DEPR-AUTH-BIO',
-    'GS001-DEPR-AUTH-LOC',
-    'GS001-DEPR-AUTH-WEB',
-    'GS001-DEPR-AUTH-TW',
-    'GS001-DEPR-AUTH-FB',
-    'GS001-DEPR-AUTH-PIMG',
-    'GS001-DEPR-AUTH-CIMG',
-    'GS001-DEPR-AUTH-URL',
-    'GS001-DEPR-PAUTH',
-    'GS001-DEPR-PAUTH-ID',
-    'GS001-DEPR-PAUTH-SLUG',
-    'GS001-DEPR-PAUTH-MAIL',
-    'GS001-DEPR-PAUTH-MT',
-    'GS001-DEPR-PAUTH-MD',
-    'GS001-DEPR-PAUTH-NAME',
-    'GS001-DEPR-PAUTH-BIO',
-    'GS001-DEPR-PAUTH-LOC',
-    'GS001-DEPR-PAUTH-WEB',
-    'GS001-DEPR-PAUTH-TW',
-    'GS001-DEPR-PAUTH-FB',
-    'GS001-DEPR-PAUTH-PIMG',
-    'GS001-DEPR-PAUTH-CIMG',
-    'GS001-DEPR-PAUTH-URL',
-    'GS001-DEPR-NAUTH',
-    'GS001-DEPR-IUA',
-    'GS001-DEPR-ESC',
-    'GS001-DEPR-BPL'
-];
-
 checkDeprecations = function checkDeprecations(theme, options, themePath) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
-    const ruleSet = spec.get([checkVersion]);
-    
-    const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
+    let ruleSet = spec.get([checkVersion]);
 
-    _.each(rulesToCheck, function (ruleCode) {
-        let check = ruleSet.rules[ruleCode];
+    // CASE: 001-deprecations checks only needs `rules` that start with `GS001-` 
+    const ruleRegex = /GS001-.*/g;
 
-        if (!check) {
-            debug(`Rule '${ruleCode}' is not defined in rulesest for version '${checkVersion}'`);
-            return;
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
         }
+    });
 
+    _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
             const template = themeFile.file.match(/^[^/]+.hbs$/) || themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
             const skipTemplateCheck = check.notValidIn && check.notValidIn.match(template);

--- a/lib/checks/002-comment-id.js
+++ b/lib/checks/002-comment-id.js
@@ -1,31 +1,21 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const debug = require('ghost-ignition').debug('checks:comment-id');
 
 let checkCommentID;
 
-// Check 1: 'GS002-DISQUS-ID'
-// Look for instances of: this.page.identifier = 'ghost-{{id}}';
-// Also the old style disqus embed: var disqus_identifier = 'ghost-{{id}}';
-// Check 2: 'GS002-ID-HELPER'
-// Look for other usages of {{id}}
-const v1RulesToCheck = ['GS002-DISQUS-ID', 'GS002-ID-HELPER'];
-const latestRulesToCheck = [];
-
 checkCommentID = function checkCommentID(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
-    const ruleSet = spec.get([checkVersion]);
-    
-    const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
+    let ruleSet = spec.get([checkVersion]);
 
-    _.each(rulesToCheck, function (ruleCode) {
-        let check = ruleSet.rules[ruleCode];
+    // CASE: 002-comment-id checks only needs `rules` that start with `GS002` 
+    const ruleRegex = /GS002-.*/g;
 
-        if (!check) {
-            debug(`Rule '${ruleCode}' is not defined in rulesest for version '${checkVersion}'`);
-            return;
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
         }
-
+    });
+    _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
             var template = themeFile.file.match(/^[^/]+.hbs$/) || themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
 

--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -7,13 +7,21 @@ const spec = require('../specs');
 let checkTemplatesCompile;
 
 checkTemplatesCompile = function checkTemplatesCompile(theme, options) {
-    const ruleToCheck = 'GS005-TPL-ERR';
     const localHbs = hbs.create();
     const failures = [];
     const checkVersion = _.get(options, 'checkVersion', 'latest');
     const ruleSet = spec.get([checkVersion]);
     
     let missingHelper;
+
+    // CASE: 001-deprecations checks only needs `rules` that start with `GS001-DEPR-` 
+    const ruleRegex = /GS005-.*/g;
+
+    const rulesToCheck = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
+        }
+    });
 
     _.each(theme.partials, function (partial) {
         // ensures partials work when running gscan on windows
@@ -25,58 +33,60 @@ checkTemplatesCompile = function checkTemplatesCompile(theme, options) {
         localHbs.registerPartial(partialName, partialContent);
     });
 
-    _.each(ruleSet.knownHelpers, function (helper) {
-        // Use standard handlebars {{each}} method for simplicity
-        if (helper === 'foreach') {
-            localHbs.handlebars.registerHelper('foreach', hbs.handlebars.helpers.each);
-        } else {
-            localHbs.handlebars.registerHelper(helper, _.noop);
-        }
-    });
-
-    _.each(theme.files, function (themeFile) {
-        let templateTest = themeFile.file.match(/^[^/]+.hbs$/);
-        let compiled;
-
-        // If this is a main template, test compiling it properly
-        if (templateTest) {
-            try {
-                // When we read the theme, we precompile, here we compile with registered partials and helpers
-                // Which will let us detect any missing partials, helpers or parse errors
-                compiled = localHbs.handlebars.compile(themeFile.content, {
-                    knownHelpers: _.zipObject(ruleSet.knownHelpers, _.map(ruleSet.knownHelpers, function () {
-                        return true;
-                    })),
-                    knownHelpersOnly: true
-                });
-
-                // NOTE: fakeData does not resolve finding unknown helpers in context objects!
-                compiled(fakeData(themeFile));
-            } catch (error) {
-                // CASE: transform ugly error message from hbs to the known error message: Missing helper: "X"
-                if (error.message.match(/you specified knownhelpersOnly/gi)) {
-                    try {
-                        missingHelper = error.message.match(/but\sused\sthe\sunknown\shelper\s(.*)\s-/)[1];
-                    } catch (err) {
-                        missingHelper = 'unknown helper name';
-                    }
-
-                    error.message = 'Missing helper: "' + missingHelper + '"';
-                }
-
-                failures.push({
-                    ref: themeFile.file,
-                    message: error.message
-                });
+    _.each(rulesToCheck, function (check, ruleCode) {
+        _.each(ruleSet.knownHelpers, function (helper) {
+            // Use standard handlebars {{each}} method for simplicity
+            if (helper === 'foreach') {
+                localHbs.handlebars.registerHelper('foreach', hbs.handlebars.helpers.each);
+            } else {
+                localHbs.handlebars.registerHelper(helper, _.noop);
             }
+        });
+    
+        _.each(theme.files, function (themeFile) {
+            let templateTest = themeFile.file.match(/^[^/]+.hbs$/);
+            let compiled;
+    
+            // If this is a main template, test compiling it properly
+            if (templateTest) {
+                try {
+                    // When we read the theme, we precompile, here we compile with registered partials and helpers
+                    // Which will let us detect any missing partials, helpers or parse errors
+                    compiled = localHbs.handlebars.compile(themeFile.content, {
+                        knownHelpers: _.zipObject(ruleSet.knownHelpers, _.map(ruleSet.knownHelpers, function () {
+                            return true;
+                        })),
+                        knownHelpersOnly: true
+                    });
+    
+                    // NOTE: fakeData does not resolve finding unknown helpers in context objects!
+                    compiled(fakeData(themeFile));
+                } catch (error) {
+                    // CASE: transform ugly error message from hbs to the known error message: Missing helper: "X"
+                    if (error.message.match(/you specified knownhelpersOnly/gi)) {
+                        try {
+                            missingHelper = error.message.match(/but\sused\sthe\sunknown\shelper\s(.*)\s-/)[1];
+                        } catch (err) {
+                            missingHelper = 'unknown helper name';
+                        }
+    
+                        error.message = 'Missing helper: "' + missingHelper + '"';
+                    }
+    
+                    failures.push({
+                        ref: themeFile.file,
+                        message: error.message
+                    });
+                }
+            }
+        });
+    
+        if (failures.length > 0) {
+            theme.results.fail[ruleCode] = {failures: failures};
+        } else {
+            theme.results.pass.push(ruleCode);
         }
     });
-
-    if (failures.length > 0) {
-        theme.results.fail[ruleToCheck] = {failures: failures};
-    } else {
-        theme.results.pass.push(ruleToCheck);
-    }
 
     return theme;
 };

--- a/lib/checks/020-theme-structure.js
+++ b/lib/checks/020-theme-structure.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const debug = require('ghost-ignition').debug('checks:theme-structure');
 
 let checkThemeStructure;
 
@@ -19,23 +18,20 @@ let checkThemeStructure;
 //    }
 //});
 
-const v1RulesToCheck = ['GS020-INDEX-REQ', 'GS020-POST-REQ', 'GS020-DEF-REC'];
-
-const latestRulesToCheck = [];
-
 checkThemeStructure = function checkThemeStructure(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
-    const ruleSet = spec.get([checkVersion]);
-    const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
+    let ruleSet = spec.get([checkVersion]);
 
-    _.each(rulesToCheck, function (ruleCode) {
-        let check = ruleSet.rules[ruleCode];
+    // CASE: 020-theme-structure checks only needs `rules` that start with `GS020-` 
+    const ruleRegex = /GS020-.*/g;
 
-        if (!check) {
-            debug(`Rule '${ruleCode}' is not defined in rulesest for version '${checkVersion}'`);
-            return;
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
         }
+    });
 
+    _.each(ruleSet, function (check, ruleCode) {
         if (!_.some(theme.files, {file: check.path})) {
             // file doesn't exist
             theme.results.fail[ruleCode] = {

--- a/lib/checks/040-ghost-head-foot.js
+++ b/lib/checks/040-ghost-head-foot.js
@@ -1,26 +1,22 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const debug = require('ghost-ignition').debug('checks:ghost-head-foot');
 
 let checkGhostHeadFoot;
 
-const v1RulesToCheck = ['GS040-GH-REQ', 'GS040-GF-REQ'];
-
-const latestRulesToCheck = [];
-
 checkGhostHeadFoot = function checkGhostHeadFoot(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
-    const ruleSet = spec.get([checkVersion]);
-    const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
+    let ruleSet = spec.get([checkVersion]);
 
-    _.each(rulesToCheck, function (ruleCode) {
-        let check = ruleSet.rules[ruleCode];
+    // CASE: 040-ghost-head-foot checks only needs `rules` that start with `GS040-` 
+    const ruleRegex = /GS040-.*/g;
 
-        if (!check) {
-            debug(`Rule '${ruleCode}' is not defined in rulesest for version '${checkVersion}'`);
-            return;
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
         }
+    });
 
+    _.each(ruleSet, function (check, ruleCode) {
         if (!theme.helpers || !theme.helpers.hasOwnProperty(check.helper)) {
             theme.results.fail[ruleCode] = {
                 failures: [{

--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -2,28 +2,24 @@ const _ = require('lodash');
 const spec = require('../specs');
 const fs = require('fs-extra');
 const path = require('path');
-const debug = require('ghost-ignition').debug('checks:koenig-css-classes');
 
 let checkKoenigCssClasses;
 
-const v1RulesToCheck = [];
-
-const latestRulesToCheck = ['GS050-CSS-KGWW', 'GS050-CSS-KGWF'];
-
 checkKoenigCssClasses = function checkKoenigCssClasses(theme, options, themePath) {
     const checkVersion = _.get(options, 'checkVersion', 'latest');
-    const ruleSet = spec.get([checkVersion]);
-    
-    const rulesToCheck = checkVersion === 'v1' ? v1RulesToCheck : _.union(v1RulesToCheck, latestRulesToCheck);
+    let ruleSet = spec.get([checkVersion]);
 
-    _.each(rulesToCheck, function (ruleCode) {
-        let check = ruleSet.rules[ruleCode];
-        let cssFiles = [];
+    // CASE: 050-koenig-css-classes checks only needs `rules` that start with `GS050-` 
+    const ruleRegex = /GS050-.*/g;
 
-        if (!check) {
-            debug(`Rule '${ruleCode}' is not defined in rulesest for version '${checkVersion}'`);
-            return;
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
         }
+    });
+
+    _.each(ruleSet, function (check, ruleCode) {
+        let cssFiles = [];
 
         // Get all CSS files
         _.each(theme.files, function (themeFile) {


### PR DESCRIPTION
closes #140

- Instead of listing all rules per checker again, we read them with a regex from the spec
- 030 assets check is currently the only check with the two rules hard coded