### PR TITLE
Fixed single author detection

### DIFF
--- a/lib/specs/latest.js
+++ b/lib/specs/latest.js
@@ -79,8 +79,8 @@ rules = {
     },
     'GS001-DEPR-AUTH': {
         level: 'error',
-        rule: '<code>{{author}}</code> should be replaced with <code>{{authors}}</code>',
-        details: `The usage of <code>{{author}}</code> is no longer valid and should be replaced with <code>{{authors}}</code>.<br>
+        rule: '<code>{{author}}</code> should be replaced with <code>{{authors}}</code> or <code>{{primary_author}}</code>',
+        details: `The usage of <code>{{author}}</code> is no longer valid and should be replaced with <code>{{authors}}</code> or <code>{{primary_author}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\s*?}}/g,
         helper: '{{author}}'
@@ -414,77 +414,231 @@ rules = {
     },
     // Updated v1 rules
     'GS001-DEPR-AC': {
-        rule: 'Replace the <code>{{primary_author.cover}}</code> helper with <code>{{primary_author.cover_image}}</code>',
+        rule: 'Replace the <code>{{author.cover}}</code> helper with <code>{{primary_author.cover_image}}</code>',
         details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
-        Instead of <code>{{primary_author.cover}}</code>, or <code>{{authors.[#].cover}}</code> you need to use 
+        Instead of <code>{{author.cover}}</code> you need to use 
         <code>{{primary_author.cover_image}}</code> or <code>{{authors.[#].cover_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?(?:author|primary_author|authors\.\[[0-9]+\])\.(cover)\s*?}}/g,
+        regex: /{{\s*?author\.cover\s*?}}/g,
+        helper: '{{author.cover}}'
+    },
+    'GS001-DEPR-AC-2': {
+        rule: 'Replace the <code>{{primary_author.cover}}</code> helper with <code>{{primary_author.cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{primary_author.cover}}</code> you need to use 
+        <code>{{primary_author.cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?primary_author\.cover\s*?}}/g,
         helper: '{{primary_author.cover}}'
     },
+    'GS001-DEPR-AC-3': {
+        rule: 'Replace the <code>{{authors.[#].cover}}</code> helper with <code>{{authors.[#].cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{authors.[#].cover}}</code> you need to use 
+        <code>{{authors.[#].cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?authors\.\[[0-9]+\]\.(cover)\s*?}}/g,
+        helper: '{{authors.[#].cover}}'
+    },
+
     'GS001-DEPR-AIMG': {
-        rule: 'Replace the <code>{{primary_author.image}}</code> helper with <code>{{primary_author.profile_image}}</code>',
+        rule: 'Replace the <code>{{author.image}}</code> helper with <code>{{primary_author.profile_image}}</code> or <code>{{authors.[#].profile_image}}</code>',
         details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
-        Instead of <code>{{primary_author.image}}</code>, or <code>{{authors.[#].image}}</code> you need to use 
+        Instead of <code>{{author.image}}</code>, you need to use 
         <code>{{primary_author.profile_image}}</code> or <code>{{authors.[#].profile_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?(?:author|primary_author|authors\.\[[0-9]+\])\.(image)\s*?}}/g,
+        regex: /{{\s*?author\.image\s*?}}/g,
+        helper: '{{author.image}}'
+    },
+    'GS001-DEPR-AIMG-2': {
+        rule: 'Replace the <code>{{primary_author.image}}</code> helper with <code>{{primary_author.profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{primary_author.image}}</code>, you need to use 
+        <code>{{primary_author.profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?primary_author\.(image)\s*?}}/g,
         helper: '{{primary_author.image}}'
     },
+    'GS001-DEPR-AIMG-3': {
+        rule: 'Replace the <code>{{authors.[#].image}}</code> helper with <code>{{authors.[#].profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{authors.[#].image}}</code>, you need to use 
+        <code>{{authors.[#].profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?authors\.\[[0-9]+\]\.(cover)\s*?}}/g,
+        helper: '{{authors.[#].image}}'
+    },
+
     'GS001-DEPR-PAC': {
-        rule: 'Replace the <code>{{post.primary_author.cover}}</code> helper with <code>{{post.primary_author.cover_image}}</code>',
+        rule: 'Replace the <code>{{post.author.cover}}</code> helper with <code>{{post.primary_author.cover_image}}</code> or <code>{{post.authors.[#].cover_image}}</code>',
         details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
-        Instead of <code>{{post.primary_author.cover}}</code>, or <code>{{post.authors.[#].cover}}</code> you need to use 
+        Instead of <code>{{post.author.cover}}</code>, you need to use 
         <code>{{post.primary_author.cover_image}}</code> or <code>{{post.authors.[#].cover_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?(?:post\.)(?:author|primary_author|authors\.\[[0-9]+\])\.(cover)\s*?}}/g,
+        regex: /{{\s*?post\.author\.cover\s*?}}/g,
+        helper: '{{post.author.cover}}'
+    },
+    'GS001-DEPR-PAC-2': {
+        rule: 'Replace the <code>{{post.primary_author.cover}}</code> helper with <code>{{post.primary_author.cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{post.primary_author.cover}}</code>, you need to use 
+        <code>{{post.primary_author.cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?post\.primary_author\.cover\s*?}}/g,
         helper: '{{post.primary_author.cover}}'
     },
+    'GS001-DEPR-PAC-3': {
+        rule: 'Replace the <code>{{post.authors.[#].cover}}</code> helper with <code>{{post.authors.[#].cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{post.authors.[#].cover}}</code>, you need to use 
+        <code>{{post.authors.[#].cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?post\.authors\.\[[0-9]+\]\.(cover)\s*?}}/g,
+        helper: '{{post.authors.[#].cover}}'
+    },
+
     'GS001-DEPR-PAIMG': {
-        rule: 'Replace the <code>{{post.primary_author.image}}</code> helper with <code>{{post.primary_author.profile_image}}</code>',
+        rule: 'Replace the <code>{{post.author.image}}</code> helper with <code>{{post.primary_author.profile_image}}</code> or <code>{{post.authors.[#].profile_image}}</code>',
         details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
-        Instead of <code>{{post.primary_author.image}}</code>, or <code>{{post.authors.[#].image}}</code> you need to use 
+        Instead of <code>{{post.author.image}}</code>, you need to use 
         <code>{{post.primary_author.profile_image}}</code> or <code>{{post.authors.[#].profile_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?(?:post\.)(?:author|primary_author|authors\.\[[0-9]+\])\.(image)\s*?}}/g,
+        regex: /{{\s*?post\.author\.image\s*?}}/g,
+        helper: '{{post.author.image}}'
+    },
+    'GS001-DEPR-PAIMG-2': {
+        rule: 'Replace the <code>{{post.primary_author.image}}</code> helper with <code>{{post.primary_author.profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{post.primary_author.image}}</code>, you need to use 
+        <code>{{post.primary_author.profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?post\.primary_author\.image\s*?}}/g,
         helper: '{{post.primary_author.image}}'
     },
+    'GS001-DEPR-PAIMG-3': {
+        rule: 'Replace the <code>{{post.authors.[#].image}}</code> helper with <code>{{post.authors.[#].profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{post.authors.[#].image}}</code>, you need to use 
+        <code>{{post.authors.[#].profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?post\.authors\.\[[0-9]+\]\.(image)\s*?}}/g,
+        helper: '{{post.authors.[#].image}}'
+    },
+
     'GS001-DEPR-CON-AC': {
-        rule: 'Replace the <code>{{#if primary_author.cover}}</code> helper with <code>{{#if primary_author.cover_image}}</code>',
+        rule: 'Replace the <code>{{#if author.cover}}</code> helper with <code>{{#if primary_author.cover_image}}</code> or <code>{{#if authors.[#].cover_image}}</code>',
         details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
-        Instead of <code>{{#if primary_author.cover}}</code>, or <code>{{#if authors.[#].cover}}</code> you need to use 
+        Instead of <code>{{#if author.cover}}</code>, you need to use 
         <code>{{#if primary_author.cover_image}}</code> or <code>{{#if authors.[#].cover_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?#if\s*?(?:author|primary_author|authors\.\[[0-9]+\])\.(cover)\s*?}}/g,
+        regex: /{{\s*?#if\s*?author\.cover\s*?}}/g,
+        helper: '{{#if author.cover}}'
+    },
+
+    'GS001-DEPR-CON-AC-2': {
+        rule: 'Replace the <code>{{#if primary_author.cover}}</code> helper with <code>{{#if primary_author.cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{#if primary_author.cover}}</code>, you need to use 
+        <code>{{#if primary_author.cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?primary_author\.cover\s*?}}/g,
         helper: '{{#if primary_author.cover}}'
     },
+
+    'GS001-DEPR-CON-AC-3': {
+        rule: 'Replace the <code>{{#if authors.[#].cover}}</code> helper with <code>{{#if authors.[#].cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{#if authors.[#].cover}}</code>, you need to use 
+        <code>{{#if authors.[#].cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?authors\.\[[0-9]+\]\.cover\s*?}}/g,
+        helper: '{{#if authors.[#].cover}}'
+    },
+
     'GS001-DEPR-CON-AIMG': {
-        rule: 'Replace the <code>{{#if primary_author.image}}</code> helper with <code>{{#if primary_author.profile_image}}</code>',
+        rule: 'Replace the <code>{{#if author.image}}</code> helper with <code>{{#if primary_author.profile_image}}</code> or <code>{{#if authors.[#].profile_image}}</code>',
         details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
-        Instead of <code>{{#if primary_author.image}}</code>, or <code>{{#if authors.[#].image}}</code> you need to use 
+        Instead of <code>{{#if author.image}}</code>, you need to use 
         <code>{{#if primary_author.profile_image}}</code> or <code>{{#if authors.[#].profile_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?#if\s*?(?:author|primary_author|authors\.\[[0-9]+\])\.(image)\s*?}}/g,
+        regex: /{{\s*?#if\s*?author\.image\s*?}}/g,
+        helper: '{{#if author.image}}'
+    },
+    'GS001-DEPR-CON-AIMG-2': {
+        rule: 'Replace the <code>{{#if primary_author.image}}</code> helper with <code>{{#if primary_author.profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{#if primary_author.image}}</code>, you need to use 
+        <code>{{#if primary_author.profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?primary_author\.image\s*?}}/g,
         helper: '{{#if primary_author.image}}'
     },
+    'GS001-DEPR-CON-AIMG-3': {
+        rule: 'Replace the <code>{{#if authors.[#].image}}</code> helper with <code>{{#if authors.[#].profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{#if authors.[#].image}}</code>, you need to use 
+        <code>{{#if authors.[#].profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?authors\.\[[0-9]+\]\.image\s*?}}/g,
+        helper: '{{#if authors.[#].image}}'
+    },
+
     'GS001-DEPR-CON-PAC': {
-        rule: 'Replace the <code>{{#if post.primary_author.cover}}</code> helper with <code>{{#if post.primary_author.cover_image}}</code>',
+        rule: 'Replace the <code>{{#if post.author.cover}}</code> helper with <code>{{#if post.primary_author.cover_image}}</code> or <code>{{#if post.authors.[#].cover_image}}</code>',
         details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
-        Instead of <code>{{#if post.primary_author.cover}}</code>, or <code>{{#if post.authors.[#].cover}}</code> you need to use 
+        Instead of <code>{{#if post.author.cover}}</code>, you need to use 
         <code>{{#if post.primary_author.cover_image}}</code> or <code>{{#if post.authors.[#].cover_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?#if\s*?(?:post\.)(?:author|primary_author|authors\.\[[0-9]+\])\.(cover)\s*?}}/g,
+        regex: /{{\s*?#if\s*?post\.author\.cover\s*?}}/g,
+        helper: '{{#if post.author.cover}}'
+    },
+    'GS001-DEPR-CON-PAC-2': {
+        rule: 'Replace the <code>{{#if post.primary_author.cover}}</code> helper with <code>{{#if post.primary_author.cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{#if post.primary_author.cover}}</code>, you need to use 
+        <code>{{#if post.primary_author.cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?post\.primary_author\.cover\s*?}}/g,
         helper: '{{#if post.primary_author.cover}}'
     },
+    'GS001-DEPR-CON-PAC-3': {
+        rule: 'Replace the <code>{{#if post.authors.[#].cover}}</code> helper with <code>{{#if post.authors.[#].cover_image}}</code>',
+        details: `The <code>cover</code> attribute was replaced with <code>cover_image</code>.<br>
+        Instead of <code>{{#if post.authors.[#].cover}}</code>, you need to use 
+        <code>{{#if post.authors.[#].cover_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?post\.authors\.\[[0-9]+\]\.cover\s*?}}/g,
+        helper: '{{#if post.authors.[#].cover}}'
+    },
+
     'GS001-DEPR-CON-PAIMG': {
-        rule: 'Replace the <code>{{#if post.primary_author.image}}</code> helper with <code>{{#if post.primary_author.profile_image}}</code>',
+        rule: 'Replace the <code>{{#if post.author.image}}</code> helper with <code>{{#if post.primary_author.profile_image}}</code> or <code>{{#if post.authors.[#].profile_image}}</code>',
         details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
-        Instead of <code>{{#if post.primary_author.image}}</code>, or <code>{{#if post.authors.[#].image}}</code> you need to use 
+        Instead of <code>{{#if post.author.image}}</code>, you need to use 
         <code>{{#if post.primary_author.profile_image}}</code> or <code>{{#if post.authors.[#].profile_image}}</code>.<br>
         See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
-        regex: /{{\s*?#if\s*?(?:post\.)(?:author|primary_author|authors\.\[[0-9]+\])\.(image)\s*?}}/g,
+        regex: /{{\s*?#if\s*?post\.author\.image\s*?}}/g,
+        helper: '{{#if post.author.image}}'
+    },
+    'GS001-DEPR-CON-PAIMG-2': {
+        rule: 'Replace the <code>{{#if post.primary_author.image}}</code> helper with <code>{{#if post.primary_author.profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{#if post.primary_author.image}}</code>, you need to use 
+        <code>{{#if post.primary_author.profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?post\.primary_author\.image\s*?}}/g,
         helper: '{{#if post.primary_author.image}}'
     },
+    'GS001-DEPR-CON-PAIMG-3': {
+        rule: 'Replace the <code>{{#if post.authors.[#].image}}</code> helper with <code>{{#if post.authors.[#].profile_image}}</code>',
+        details: `The <code>image</code> attribute was replaced with <code>profile_image</code>.<br>
+        Instead of <code>{{#if post.authors.[#].image}}</code>, you need to use 
+        <code>{{#if post.authors.[#].profile_image}}</code>.<br>
+        See the object attributes of <code>author</code> <a href="${docsBaseUrl}author-context#section-author-object-attributes" target=_blank>here</a>.`,
+        regex: /{{\s*?#if\s*?post\.authors\.\[[0-9]+\]\.image\s*?}}/g,
+        helper: '{{#if post.authors.[#].image}}'
+    },
+
     'GS010-PJ-KEYWORDS': {
         level: 'warning',
         rule: '<code>package.json</code> property <code>keywords</code> should contain <code>ghost-theme</code>',

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -9,7 +9,7 @@ describe('001 Deprecations', function () {
         it('[failure] theme is invalid', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/v1/invalid', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().with.keys(
                     'GS001-DEPR-PURL',
                     'GS001-DEPR-MD',
@@ -40,120 +40,120 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-CSS-PA',
                     'GS001-DEPR-CSS-PATS'
                 );
-    
+
                 // pageUrl
                 output.results.fail['GS001-DEPR-PURL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PURL'].failures.length.should.eql(3);
-    
+
                 // meta_description in <head>
                 output.results.fail['GS001-DEPR-MD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-MD'].failures.length.should.eql(1);
-    
+
                 // {{image}}
                 output.results.fail['GS001-DEPR-IMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IMG'].failures.length.should.eql(2);
-    
+
                 // {{cover}}
                 output.results.fail['GS001-DEPR-COV'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-COV'].failures.length.should.eql(3);
-    
+
                 // {{author.image}}
                 output.results.fail['GS001-DEPR-AIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AIMG'].failures.length.should.eql(2);
-    
+
                 // {{post.image}}
                 output.results.fail['GS001-DEPR-PIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PIMG'].failures.length.should.eql(1);
-    
+
                 // {{@blog.cover}}
                 output.results.fail['GS001-DEPR-BC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BC'].failures.length.should.eql(1);
-    
+
                 // {{author.cover}}
                 output.results.fail['GS001-DEPR-AC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AC'].failures.length.should.eql(2);
-    
+
                 // {{post.author.cover}}
                 output.results.fail['GS001-DEPR-PAC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAC'].failures.length.should.eql(1);
-    
+
                 // {{post.author.image}}
                 output.results.fail['GS001-DEPR-PAIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAIMG'].failures.length.should.eql(1);
-    
+
                 // {{tag.image}}
                 output.results.fail['GS001-DEPR-TIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-TIMG'].failures.length.should.eql(1);
-    
+
                 // {{posts.tags.[4].image}}
                 output.results.fail['GS001-DEPR-PTIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PTIMG'].failures.length.should.eql(1);
-    
+
                 // {{tags.[4].image}}
                 output.results.fail['GS001-DEPR-TSIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-TSIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if image}}
                 output.results.fail['GS001-DEPR-CON-IMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-IMG'].failures.length.should.eql(1);
-    
+
                 // {{#if cover}}
                 output.results.fail['GS001-DEPR-CON-COV'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-COV'].failures.length.should.eql(1);
-    
+
                 // {{#if tag.image}}
                 output.results.fail['GS001-DEPR-CON-TIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-TIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if tags.[#].image}}
                 output.results.fail['GS001-DEPR-CON-TSIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-TSIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if post.tags.[#].image}}
                 output.results.fail['GS001-DEPR-CON-PTIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-PTIMG'].failures.length.should.eql(1);
-    
+
                 // {{@blog.posts_per_page}}
                 output.results.fail['GS001-DEPR-PPP'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PPP'].failures.length.should.eql(1);
-    
+
                 // {{content word="0"}}
                 output.results.fail['GS001-DEPR-C0H'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-C0H'].failures.length.should.eql(2);
-    
+
                 // css class .page
                 output.results.fail['GS001-DEPR-CSS-PA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-PA'].failures.length.should.eql(2);
-    
+
                 // css class .page-template-{slug}
                 output.results.fail['GS001-DEPR-CSS-PATS'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-PATS'].failures.length.should.eql(2);
-    
+
                 // css class .achive-template
                 output.results.fail['GS001-DEPR-CSS-AT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-AT'].failures.length.should.eql(1);
-    
+
                 output.results.pass.should.be.an.Object().which.is.empty();
-    
+
                 done();
             }).catch(done);
         });
-    
+
         it('[success] should show no error if no deprecated helpers used', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/v1/valid', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().which.is.empty();
                 output.results.pass.should.be.an.Array().with.lengthOf(28);
-    
+
                 done();
             }).catch(done);
         });
-    
+
         it('[mixed] should pass and fail when some rules pass and others fail', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/v1/mixed', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().with.keys(
                     'GS001-DEPR-PURL',
                     'GS001-DEPR-MD',
@@ -164,11 +164,11 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-TIMG',
                     'GS001-DEPR-C0H'
                 );
-    
+
                 output.results.fail['GS001-DEPR-PURL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PURL'].failures.length.should.eql(2);
                 output.results.pass.should.be.an.Array().with.lengthOf(20);
-    
+
                 done();
             }).catch(done);
         });
@@ -178,7 +178,7 @@ describe('001 Deprecations', function () {
         it('[failure] theme is completely invalid (v1 and latest)', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/latest/invalid_all').then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().with.keys(
                     'GS001-DEPR-PURL',
                     'GS001-DEPR-MD',
@@ -250,95 +250,95 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-ESC',
                     'GS001-DEPR-BPL'
                 );
-    
+
                 // pageUrl
                 output.results.fail['GS001-DEPR-PURL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PURL'].failures.length.should.eql(3);
-    
+
                 // meta_description in <head>
                 output.results.fail['GS001-DEPR-MD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-MD'].failures.length.should.eql(1);
-    
+
                 // {{image}}
                 output.results.fail['GS001-DEPR-IMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IMG'].failures.length.should.eql(2);
-    
+
                 // {{cover}}
                 output.results.fail['GS001-DEPR-COV'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-COV'].failures.length.should.eql(3);
-    
+
                 // {{primary_author.image}}
                 output.results.fail['GS001-DEPR-AIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AIMG'].failures.length.should.eql(2);
-    
+
                 // {{post.image}}
                 output.results.fail['GS001-DEPR-PIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PIMG'].failures.length.should.eql(1);
-    
+
                 // {{@blog.cover}}
                 output.results.fail['GS001-DEPR-BC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BC'].failures.length.should.eql(1);
-    
+
                 // {{author.cover}}
                 output.results.fail['GS001-DEPR-AC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AC'].failures.length.should.eql(2);
-    
+
                 // {{post.author.cover}}
                 output.results.fail['GS001-DEPR-PAC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAC'].failures.length.should.eql(1);
-    
+
                 // {{post.author.image}}
                 output.results.fail['GS001-DEPR-PAIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAIMG'].failures.length.should.eql(1);
-    
+
                 // {{tag.image}}
                 output.results.fail['GS001-DEPR-TIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-TIMG'].failures.length.should.eql(1);
-    
+
                 // {{posts.tags.[4].image}}
                 output.results.fail['GS001-DEPR-PTIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PTIMG'].failures.length.should.eql(1);
-    
+
                 // {{tags.[4].image}}
                 output.results.fail['GS001-DEPR-TSIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-TSIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if image}}
                 output.results.fail['GS001-DEPR-CON-IMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-IMG'].failures.length.should.eql(1);
-    
+
                 // {{#if cover}}
                 output.results.fail['GS001-DEPR-CON-COV'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-COV'].failures.length.should.eql(1);
-    
+
                 // {{#if tag.image}}
                 output.results.fail['GS001-DEPR-CON-TIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-TIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if tags.[#].image}}
                 output.results.fail['GS001-DEPR-CON-TSIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-TSIMG'].failures.length.should.eql(1);
-    
+
                 // {{#if post.tags.[#].image}}
                 output.results.fail['GS001-DEPR-CON-PTIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-PTIMG'].failures.length.should.eql(1);
-    
+
                 // {{@blog.posts_per_page}}
                 output.results.fail['GS001-DEPR-PPP'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PPP'].failures.length.should.eql(1);
-    
+
                 // {{content word="0"}}
                 output.results.fail['GS001-DEPR-C0H'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-C0H'].failures.length.should.eql(2);
-    
+
                 // css class .page
                 output.results.fail['GS001-DEPR-CSS-PA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-PA'].failures.length.should.eql(2);
-    
+
                 // css class .page-template-{slug}
                 output.results.fail['GS001-DEPR-CSS-PATS'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-PATS'].failures.length.should.eql(2);
-    
+
                 // css class .achive-template
                 output.results.fail['GS001-DEPR-CSS-AT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-AT'].failures.length.should.eql(1);
@@ -346,7 +346,7 @@ describe('001 Deprecations', function () {
                 // css class .kg-card-markdown
                 output.results.fail['GS001-DEPR-CSS-KGMD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-KGMD'].failures.length.should.eql(5);
-    
+
                 // {{#get "posts" include="author"}}
                 output.results.fail['GS001-DEPR-AUTH-INCL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-INCL'].failures.length.should.eql(1);
@@ -362,11 +362,11 @@ describe('001 Deprecations', function () {
                 // {{#author}} but not in author.hbs
                 output.results.fail['GS001-DEPR-AUTHBL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTHBL'].failures.length.should.eql(1);
-                
+
                 // {{#if author}} or {{#if author.*}}
                 output.results.fail['GS001-DEPR-CON-AUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-AUTH'].failures.length.should.eql(3);
-                
+
                 // {{#if post.author}} or {{#if post.author.*}}
                 output.results.fail['GS001-DEPR-CON-PAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-PAUTH'].failures.length.should.eql(1);
@@ -426,7 +426,7 @@ describe('001 Deprecations', function () {
                 // {{author.cover_image}}
                 output.results.fail['GS001-DEPR-AUTH-CIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-CIMG'].failures.length.should.eql(1);
-                
+
                 // {{author.url}}
                 output.results.fail['GS001-DEPR-AUTH-URL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-URL'].failures.length.should.eql(1);
@@ -434,7 +434,7 @@ describe('001 Deprecations', function () {
                 // {{post.author}}
                 output.results.fail['GS001-DEPR-PAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH'].failures.length.should.eql(1);
-                
+
                 // {{post.author.id}}
                 output.results.fail['GS001-DEPR-PAUTH-ID'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-ID'].failures.length.should.eql(1);
@@ -442,51 +442,51 @@ describe('001 Deprecations', function () {
                 // {{post.author.slug}}
                 output.results.fail['GS001-DEPR-PAUTH-SLUG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-SLUG'].failures.length.should.eql(1);
-                
+
                 // {{post.author.email}}
                 output.results.fail['GS001-DEPR-PAUTH-MAIL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MAIL'].failures.length.should.eql(1);
-                
+
                 // {{post.author.meta_title}}
                 output.results.fail['GS001-DEPR-PAUTH-MT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MT'].failures.length.should.eql(1);
-                
+
                 // {{post.author.meta_description}}
                 output.results.fail['GS001-DEPR-PAUTH-MD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MD'].failures.length.should.eql(1);
-                
+
                 // {{post.author.name}}
                 output.results.fail['GS001-DEPR-PAUTH-NAME'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-NAME'].failures.length.should.eql(1);
-                
+
                 // {{post.author.bio}}
                 output.results.fail['GS001-DEPR-PAUTH-BIO'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-BIO'].failures.length.should.eql(1);
-                
+
                 // {{post.author.location}}
                 output.results.fail['GS001-DEPR-PAUTH-LOC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-LOC'].failures.length.should.eql(1);
-                
+
                 // {{post.author.website}}
                 output.results.fail['GS001-DEPR-PAUTH-WEB'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-WEB'].failures.length.should.eql(1);
-                
+
                 // {{post.author.twitter}}
                 output.results.fail['GS001-DEPR-PAUTH-TW'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-TW'].failures.length.should.eql(1);
-                
+
                 // {{post.author.facebook}}
                 output.results.fail['GS001-DEPR-PAUTH-FB'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-FB'].failures.length.should.eql(1);
-                
+
                 // {{post.author.profile_image}}
                 output.results.fail['GS001-DEPR-PAUTH-PIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-PIMG'].failures.length.should.eql(1);
-                
+
                 // {{post.author.cover_image}}
                 output.results.fail['GS001-DEPR-PAUTH-CIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-CIMG'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.url}}
                 output.results.fail['GS001-DEPR-PAUTH-URL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-URL'].failures.length.should.eql(1);
@@ -495,7 +495,7 @@ describe('001 Deprecations', function () {
                 // {{#../author.*}}, {{../author.*}}, {{#if../author.*}}
                 output.results.fail['GS001-DEPR-NAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-NAUTH'].failures.length.should.eql(1);
-                
+
                 // {{img_url author.*}}
                 output.results.fail['GS001-DEPR-IUA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IUA'].failures.length.should.eql(1);
@@ -503,13 +503,14 @@ describe('001 Deprecations', function () {
                 // {{error.statusCode}}
                 output.results.fail['GS001-DEPR-ESC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-ESC'].failures.length.should.eql(2);
-                
+
                 // {{@blog.permalinks}}
                 output.results.fail['GS001-DEPR-BPL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BPL'].failures.length.should.eql(1);
 
-                output.results.pass.should.be.an.Object().which.is.empty();
-    
+                // there are some single author rules which are not invalid for this theme.
+                output.results.pass.length.should.eql(16);
+
                 done();
             }).catch(done);
         });
@@ -558,11 +559,11 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-PAUTH-URL',
                     'GS001-DEPR-NAUTH',
                     'GS001-DEPR-IUA',
-                    'GS001-DEPR-AIMG',
+                    'GS001-DEPR-AIMG-2',
                     'GS001-DEPR-ESC',
                     'GS001-DEPR-BPL'
                 );
-    
+
                 // css class .kg-card-markdown
                 output.results.fail['GS001-DEPR-CSS-KGMD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CSS-KGMD'].failures.length.should.eql(1);
@@ -570,7 +571,7 @@ describe('001 Deprecations', function () {
                 // {{#get "posts" include="author"}}
                 output.results.fail['GS001-DEPR-AUTH-INCL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-INCL'].failures.length.should.eql(1);
-                
+
                 // {{#get "posts" fields="author"}}
                 output.results.fail['GS001-DEPR-AUTH-FIELD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-FIELD'].failures.length.should.eql(1);
@@ -578,15 +579,15 @@ describe('001 Deprecations', function () {
                 // {{#get "posts" filter="author:[...]"}}
                 output.results.fail['GS001-DEPR-AUTH-FILT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-FILT'].failures.length.should.eql(1);
-                
+
                 // {{#author}} but not in author.hbs
                 output.results.fail['GS001-DEPR-AUTHBL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTHBL'].failures.length.should.eql(1);
-                
+
                 // {{#if author}} or {{#if author.*}}
                 output.results.fail['GS001-DEPR-CON-AUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-AUTH'].failures.length.should.eql(3);
-                
+
                 // {{#if post.author}} or {{#if post.author.*}}
                 output.results.fail['GS001-DEPR-CON-PAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-CON-PAUTH'].failures.length.should.eql(1);
@@ -594,7 +595,7 @@ describe('001 Deprecations', function () {
                 // {{author}}
                 output.results.fail['GS001-DEPR-AUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH'].failures.length.should.eql(1);
-    
+
                 // {{author.id}}
                 output.results.fail['GS001-DEPR-AUTH-ID'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-ID'].failures.length.should.eql(1);
@@ -602,15 +603,15 @@ describe('001 Deprecations', function () {
                 // {{author.slug}}
                 output.results.fail['GS001-DEPR-AUTH-SLUG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-SLUG'].failures.length.should.eql(2);
-                
+
                 // {{author.email}}
                 output.results.fail['GS001-DEPR-AUTH-MAIL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-MAIL'].failures.length.should.eql(1);
-                
+
                 // {{author.meta_title}}
                 output.results.fail['GS001-DEPR-AUTH-MT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-MT'].failures.length.should.eql(1);
-                
+
                 // {{author.meta_description}}
                 output.results.fail['GS001-DEPR-AUTH-MD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-MD'].failures.length.should.eql(1);
@@ -646,7 +647,7 @@ describe('001 Deprecations', function () {
                 // {{author.cover_image}}
                 output.results.fail['GS001-DEPR-AUTH-CIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-CIMG'].failures.length.should.eql(1);
-                
+
                 // {{author.url}}
                 output.results.fail['GS001-DEPR-AUTH-URL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-URL'].failures.length.should.eql(1);
@@ -654,7 +655,7 @@ describe('001 Deprecations', function () {
                 // {{post.author}}
                 output.results.fail['GS001-DEPR-PAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.id}}
                 output.results.fail['GS001-DEPR-PAUTH-ID'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-ID'].failures.length.should.eql(1);
@@ -662,51 +663,51 @@ describe('001 Deprecations', function () {
                 // {{post.author.slug}}
                 output.results.fail['GS001-DEPR-PAUTH-SLUG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-SLUG'].failures.length.should.eql(1);
-                
+
                 // {{post.author.email}}
                 output.results.fail['GS001-DEPR-PAUTH-MAIL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MAIL'].failures.length.should.eql(1);
-                
+
                 // {{post.author.meta_title}}
                 output.results.fail['GS001-DEPR-PAUTH-MT'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MT'].failures.length.should.eql(1);
-                
+
                 // {{post.author.meta_description}}
                 output.results.fail['GS001-DEPR-PAUTH-MD'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-MD'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.name}}
                 output.results.fail['GS001-DEPR-PAUTH-NAME'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-NAME'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.bio}}
                 output.results.fail['GS001-DEPR-PAUTH-BIO'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-BIO'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.location}}
                 output.results.fail['GS001-DEPR-PAUTH-LOC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-LOC'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.website}}
                 output.results.fail['GS001-DEPR-PAUTH-WEB'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-WEB'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.twitter}}
                 output.results.fail['GS001-DEPR-PAUTH-TW'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-TW'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.facebook}}
                 output.results.fail['GS001-DEPR-PAUTH-FB'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-FB'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.profile_image}}
                 output.results.fail['GS001-DEPR-PAUTH-PIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-PIMG'].failures.length.should.eql(1);
-                                
+
                 // {{post.author.cover_image}}
                 output.results.fail['GS001-DEPR-PAUTH-CIMG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-CIMG'].failures.length.should.eql(1);
-                                                
+
                 // {{post.author.url}}
                 output.results.fail['GS001-DEPR-PAUTH-URL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-PAUTH-URL'].failures.length.should.eql(1);
@@ -715,25 +716,25 @@ describe('001 Deprecations', function () {
                 // {{#../author.*}}, {{../author.*}}, {{#if../author.*}}
                 output.results.fail['GS001-DEPR-NAUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-NAUTH'].failures.length.should.eql(1);
-                
+
                 // {{img_url author.*}}
                 output.results.fail['GS001-DEPR-IUA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IUA'].failures.length.should.eql(1);
-    
+
                 // {{primary_author.image}}
-                output.results.fail['GS001-DEPR-AIMG'].should.be.a.ValidFailObject();
-                output.results.fail['GS001-DEPR-AIMG'].failures.length.should.eql(1);
+                output.results.fail['GS001-DEPR-AIMG-2'].should.be.a.ValidFailObject();
+                output.results.fail['GS001-DEPR-AIMG-2'].failures.length.should.eql(1);
 
                 // {{error.statusCode}}
                 output.results.fail['GS001-DEPR-ESC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-ESC'].failures.length.should.eql(2);
-                
+
                 // {{@blog.permalinks}}
                 output.results.fail['GS001-DEPR-BPL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BPL'].failures.length.should.eql(1);
 
-                output.results.pass.should.be.an.Array().with.lengthOf(27);
-    
+                output.results.pass.should.be.an.Array().with.lengthOf(43);
+
                 done();
             }).catch(done);
         });
@@ -741,18 +742,18 @@ describe('001 Deprecations', function () {
         it('[success] should show no error if no deprecated helpers used', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/latest/valid').then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().which.is.empty();
-                output.results.pass.should.be.an.Array().with.lengthOf(69);
-    
+                output.results.pass.should.be.an.Array().with.lengthOf(85);
+
                 done();
             }).catch(done);
         });
-    
+
         it('[mixed] should pass and fail when some rules pass and others fail', function (done) {
             utils.testCheck(thisCheck, '001-deprecations/latest/mixed').then(function (output) {
                 output.should.be.a.ValidThemeObject();
-    
+
                 output.results.fail.should.be.an.Object().with.keys(
                     'GS001-DEPR-IMG',
                     'GS001-DEPR-C0H',
@@ -790,17 +791,17 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-ESC',
                     'GS001-DEPR-BPL'
                 );
-    
+
                 output.results.fail['GS001-DEPR-AUTH-INCL'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH-INCL'].failures.length.should.eql(1);
 
                 output.results.fail['GS001-DEPR-AUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH'].failures.length.should.eql(1);
 
-                output.results.pass.should.be.an.Array().with.lengthOf(35);
-    
+                output.results.pass.should.be.an.Array().with.lengthOf(51);
+
                 done();
             }).catch(done);
-        });    
+        });
     });
 });

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -322,7 +322,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(74);
+            theme.results.pass.should.be.an.Array().with.lengthOf(90);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(


### PR DESCRIPTION
refs #99

- the rules haven't really worked
- i had to add much more rules to output the correct rules and messages

e.g. your theme uses

{{author.image}}

And GScan was showing

> Replace the <code>{{primary_author.image}}</code> helper with <code>{{primary_author.profile_image}}</code>

- this was caused by using generic rules
- i know this PR is not nice, but rewriting this takes much more time