### PR TITLE
✨ Added exit code to CLI for programmatic usage

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,6 +40,8 @@ function outputResult(result) {
 
 function outputResults(theme, options) {
     theme = gscan.format(theme, options);
+    let errorCount = theme.results.error.length;
+    let warnCount = theme.results.warning.length;
 
     console.log(chalk.bold.underline(`\nRule Report for v${theme.checkedVersion}:`));
 
@@ -62,7 +64,23 @@ function outputResults(theme, options) {
         console.log(chalk.green.bold.underline('\n\u2713', theme.results.pass.length, 'Passed Rules'));
     }
 
-    console.log('\n...checks complete.');
+    if (errorCount > 0 || warnCount > 0) {
+        let errorString = 'Checks failed with ';
+        // This is a failure case
+        if (errorCount > 0 && warnCount > 0) {
+            errorString += `${errorCount} errors and ${warnCount} warnings.`;
+        } else if (errorCount > 0) {
+            errorString += `${errorCount} errors.`;
+        } else if (warnCount > 0) {
+            errorString += `${warnCount} warnings.`;
+        }
+
+        console.error(errorString);
+        process.exit(1);
+    } else {
+        console.log('\nChecks completed without errors.');
+        process.exit(0);
+    }
 }
 
 if (!program.args.length) {


### PR DESCRIPTION
Note: This PR is instead of https://github.com/TryGhost/gscan/pull/108

I tried to cleanup that PR but I could not get it to work for me. This change is a little bit simpler and can probably be improved upon.

If there is an error or a warning, we exit with code 1. Else with code 0. 

I show a summary message at the end.

You can see this PR working in Casper:

[with a deliberate error](https://travis-ci.org/ErisDS/Casper/builds/415992710)
[with a deliberate warning](https://travis-ci.org/ErisDS/Casper/builds/415992587)
[travis branch off of 2.0 branch is passing](https://travis-ci.org/ErisDS/Casper/builds/415991831)

closes #105

- Show exit code 1 if there are any errors or warnings
- We show this for warnings because warnings are still things that should be fixed e.g. will be errors in the next version
- The purpose of exit codes is for CI, so that themes can validate they are getting as good a score as possible
- Therefore it makes sense to get a failure for warnings
- Also output a quick summary