### PR TITLE
🎨 Optimised GScan rule messages

### DIFF
--- a/lib/specs/latest.js
+++ b/lib/specs/latest.js
@@ -19,7 +19,7 @@ rules = {
     'GS001-DEPR-AUTH-INCL': {
         level: 'error',
         rule: `<code>include="author"</code> should be replaced with <code>include="authors"</code>`,
-        details: `The usage of <code>{{#get "posts" include="author"}}</code> is no longer valid and should be replaced with <code>{{#get "posts" include="authors"}}</code>.<br>
+        details: `The usage of <code>{{#get "posts" include="author"}}</code> is deprecated and should be replaced with <code>{{#get "posts" include="authors"}}</code>.<br>
         Find more information about the <code>{{get}}</code> helper <a href="${docsBaseUrl}get" target=_blank>here</a>.`,
         // This regex seems only to work properly with the escaped characters. Removing them resulted
         // in not detecting the wrong usage.
@@ -29,7 +29,7 @@ rules = {
     'GS001-DEPR-AUTH-FIELD': {
         level: 'error',
         rule: `<code>fields="author"</code> should be replaced with <code>fields="authors"</code>`,
-        details: `The usage of <code>{{#get "posts" fields="author"}}</code> is no longer valid and should be replaced with 
+        details: `The usage of <code>{{#get "posts" fields="author"}}</code> is deprecated and should be replaced with 
         <code>{{#get "posts" fields="primary_author"}}</code> or <code>{{#get "posts" fields="authors.[#]"}}</code>.<br>
         Find more information about the <code>{{get}}</code> helper <a href="${docsBaseUrl}get" target=_blank>here</a>.`,
         // This regex seems only to work properly with the escaped characters. Removing them resulted
@@ -40,7 +40,7 @@ rules = {
     'GS001-DEPR-AUTH-FILT': {
         level: 'error',
         rule: `<code>filter="author:[...]"</code> should be replaced with <code>filter="authors:[...]"</code>`,
-        details: `The usage of <code>{{#get "posts" filter="author:[...]"}}</code> is no longer valid and should be replaced with <code>{{#get "posts" filter="authors:[...]"}}</code>.<br>
+        details: `The usage of <code>{{#get "posts" filter="author:[...]"}}</code> is deprecated and should be replaced with <code>{{#get "posts" filter="authors:[...]"}}</code>.<br>
         Find more information about the <code>{{get}}</code> helper <a href="${docsBaseUrl}get" target=_blank>here</a>.`,
         // This regex seems only to work properly with the escaped characters. Removing them resulted
         // in not detecting the wrong usage.
@@ -49,9 +49,9 @@ rules = {
     },
     'GS001-DEPR-AUTHBL': {
         level: 'error',
-        rule: 'The <code>{{#author}}</code> block helper should be replaced with <code>{{#primary_author}}</code>',
-        details: `The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is no longer valid and 
-        should be replaced with <code>{{#primary_author}}</code>.<br>
+        rule: 'The <code>{{#author}}</code> block helper should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>',
+        details: `The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is deprecated and 
+        should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?#author\s*?}}/g,
         notValidIn: 'author.hbs',
@@ -61,7 +61,7 @@ rules = {
         level: 'error',
         rule: `The <code>{{#if author.*}}</code> block helper should be replaced with <code>{{#if primary_author.*}}</code> 
         or <code>{{#if authors.[#].*}}</code>`,
-        details: `The usage of <code>{{#if author.*}}</code> is no longer valid and should be replaced with <code>{{#if primary_author.*}}</code> 
+        details: `The usage of <code>{{#if author.*}}</code> is deprecated and should be replaced with <code>{{#if primary_author.*}}</code> 
         or <code>{{#if authors.[#].*}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?#if\s*?(author)(?:\.\w+)*?\s*?}}/g,
@@ -71,7 +71,7 @@ rules = {
         level: 'error',
         rule: `The <code>{{#if post.author.*}}</code> block helper should be replaced with <code>{{#if post.primary_author.*}}</code> 
         or <code>{{#if post.authors.[#].*}}</code>`,
-        details: `The usage of <code>{{#if post.author.*}}</code> is no longer valid and should be replaced with <code>{{#if post.primary_author.*}}</code> 
+        details: `The usage of <code>{{#if post.author.*}}</code> is deprecated and should be replaced with <code>{{#if post.primary_author.*}}</code> 
         or <code>{{#if post.authors.[#].*}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?#if\s*?(?:post\.)(author)(?:\.\w+)*?\s*?}}/g,
@@ -79,8 +79,8 @@ rules = {
     },
     'GS001-DEPR-AUTH': {
         level: 'error',
-        rule: '<code>{{author}}</code> should be replaced with <code>{{authors}}</code> or <code>{{primary_author}}</code>',
-        details: `The usage of <code>{{author}}</code> is no longer valid and should be replaced with <code>{{authors}}</code> or <code>{{primary_author}}</code>.<br>
+        rule: '<code>{{author}}</code> should be replaced with <code>{{authors}}</code>',
+        details: `The usage of <code>{{author}}</code> is deprecated and should be replaced with <code>{{authors}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\s*?}}/g,
         helper: '{{author}}'
@@ -88,7 +88,7 @@ rules = {
     'GS001-DEPR-AUTH-ID': {
         level: 'error',
         rule: 'Replace the <code>{{author.id}}</code> helper with <code>{{primary_author.id}}</code> or <code>{{authors.[#].id}}</code>',
-        details: `The usage of <code>{{author.id}}</code> is no longer valid and should be replaced with either <code>{{primary_author.id}}</code>
+        details: `The usage of <code>{{author.id}}</code> is deprecated and should be replaced with either <code>{{primary_author.id}}</code>
         or <code>{{authors.[#].id}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.id\s*?}}/g,
@@ -97,7 +97,7 @@ rules = {
     'GS001-DEPR-AUTH-SLUG': {
         level: 'error',
         rule: 'Replace the <code>{{author.slug}}</code> helper with <code>{{primary_author.slug}}</code> or <code>{{authors.[#].slug}}</code>',
-        details: `The usage of <code>{{author.slug}}</code> is no longer valid and should be replaced with either <code>{{primary_author.slug}}</code>
+        details: `The usage of <code>{{author.slug}}</code> is deprecated and should be replaced with either <code>{{primary_author.slug}}</code>
         or <code>{{authors.[#].slug}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.slug\s*?}}/g,
@@ -106,7 +106,7 @@ rules = {
     'GS001-DEPR-AUTH-MAIL': {
         level: 'error',
         rule: 'Replace the <code>{{author.email}}</code> helper with <code>{{primary_author.email}}</code> or <code>{{authors.[#].email}}</code>',
-        details: `The usage of <code>{{author.email}}</code> is no longer valid and should be replaced with either <code>{{primary_author.email}}</code>
+        details: `The usage of <code>{{author.email}}</code> is deprecated and should be replaced with either <code>{{primary_author.email}}</code>
         or <code>{{authors.[#].email}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.email\s*?}}/g,
@@ -115,7 +115,7 @@ rules = {
     'GS001-DEPR-AUTH-MT': {
         level: 'error',
         rule: 'Replace the <code>{{author.meta_title}}</code> helper with <code>{{primary_author.meta_title}}</code> or <code>{{authors.[#].meta_title}}</code>',
-        details: `The usage of <code>{{author.meta_title}}</code> is no longer valid and should be replaced with either <code>{{primary_author.meta_title}}</code>
+        details: `The usage of <code>{{author.meta_title}}</code> is deprecated and should be replaced with either <code>{{primary_author.meta_title}}</code>
         or <code>{{authors.[#].meta_title}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.meta_title\s*?}}/g,
@@ -124,7 +124,7 @@ rules = {
     'GS001-DEPR-AUTH-MD': {
         level: 'error',
         rule: 'Replace the <code>{{author.meta_description}}</code> helper with <code>{{primary_author.meta_description}}</code> or <code>{{authors.[#].meta_description}}</code>',
-        details: `The usage of <code>{{author.meta_description}}</code> is no longer valid and should be replaced with either <code>{{primary_author.meta_description}}</code>
+        details: `The usage of <code>{{author.meta_description}}</code> is deprecated and should be replaced with either <code>{{primary_author.meta_description}}</code>
         or <code>{{authors.[#].meta_description}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.meta_description\s*?}}/g,
@@ -133,7 +133,7 @@ rules = {
     'GS001-DEPR-AUTH-NAME': {
         level: 'error',
         rule: 'Replace the <code>{{author.name}}</code> helper with <code>{{primary_author.name}}</code> or <code>{{authors.[#].name}}</code>',
-        details: `The usage of <code>{{author.name}}</code> is no longer valid and should be replaced with either <code>{{primary_author.name}}</code>
+        details: `The usage of <code>{{author.name}}</code> is deprecated and should be replaced with either <code>{{primary_author.name}}</code>
         or <code>{{authors.[#].name}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.name\s*?}}/g,
@@ -142,7 +142,7 @@ rules = {
     'GS001-DEPR-AUTH-BIO': {
         level: 'error',
         rule: 'Replace the <code>{{author.bio}}</code> helper with <code>{{primary_author.bio}}</code> or <code>{{authors.[#].bio}}</code>',
-        details: `The usage of <code>{{author.bio}}</code> is no longer valid and should be replaced with either <code>{{primary_author.bio}}</code>
+        details: `The usage of <code>{{author.bio}}</code> is deprecated and should be replaced with either <code>{{primary_author.bio}}</code>
         or <code>{{authors.[#].bio}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.bio\s*?}}/g,
@@ -151,7 +151,7 @@ rules = {
     'GS001-DEPR-AUTH-LOC': {
         level: 'error',
         rule: 'Replace the <code>{{author.location}}</code> helper with <code>{{primary_author.location}}</code> or <code>{{authors.[#].location}}</code>',
-        details: `The usage of <code>{{author.location}}</code> is no longer valid and should be replaced with either <code>{{primary_author.location}}</code>
+        details: `The usage of <code>{{author.location}}</code> is deprecated and should be replaced with either <code>{{primary_author.location}}</code>
         or <code>{{authors.[#].location}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.location\s*?}}/g,
@@ -160,7 +160,7 @@ rules = {
     'GS001-DEPR-AUTH-WEB': {
         level: 'error',
         rule: 'Replace the <code>{{author.website}}</code> helper with <code>{{primary_author.website}}</code> or <code>{{authors.[#].website}}</code>',
-        details: `The usage of <code>{{author.website}}</code> is no longer valid and should be replaced with either <code>{{primary_author.website}}</code>
+        details: `The usage of <code>{{author.website}}</code> is deprecated and should be replaced with either <code>{{primary_author.website}}</code>
         or <code>{{authors.[#].website}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.website\s*?}}/g,
@@ -169,7 +169,7 @@ rules = {
     'GS001-DEPR-AUTH-TW': {
         level: 'error',
         rule: 'Replace the <code>{{author.twitter}}</code> helper with <code>{{primary_author.twitter}}</code> or <code>{{authors.[#].twitter}}</code>',
-        details: `The usage of <code>{{author.twitter}}</code> is no longer valid and should be replaced with either <code>{{primary_author.twitter}}</code>
+        details: `The usage of <code>{{author.twitter}}</code> is deprecated and should be replaced with either <code>{{primary_author.twitter}}</code>
         or <code>{{authors.[#].twitter}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.twitter\s*?}}/g,
@@ -178,7 +178,7 @@ rules = {
     'GS001-DEPR-AUTH-FB': {
         level: 'error',
         rule: 'Replace the <code>{{author.facebook}}</code> helper with <code>{{primary_author.facebook}}</code> or <code>{{authors.[#].facebook}}</code>',
-        details: `The usage of <code>{{author.facebook}}</code> is no longer valid and should be replaced with either <code>{{primary_author.facebook}}</code>
+        details: `The usage of <code>{{author.facebook}}</code> is deprecated and should be replaced with either <code>{{primary_author.facebook}}</code>
         or <code>{{authors.[#].facebook}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.facebook\s*?}}/g,
@@ -187,7 +187,7 @@ rules = {
     'GS001-DEPR-AUTH-PIMG': {
         level: 'error',
         rule: 'Replace the <code>{{author.profile_image}}</code> helper with <code>{{primary_author.profile_image}}</code> or <code>{{authors.[#].profile_image}}</code>',
-        details: `The usage of <code>{{author.profile_image}}</code> is no longer valid and should be replaced with either <code>{{primary_author.profile_image}}</code>
+        details: `The usage of <code>{{author.profile_image}}</code> is deprecated and should be replaced with either <code>{{primary_author.profile_image}}</code>
         or <code>{{authors.[#].profile_image}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.profile_image\s*?}}/g,
@@ -196,7 +196,7 @@ rules = {
     'GS001-DEPR-AUTH-CIMG': {
         level: 'error',
         rule: 'Replace the <code>{{author.cover_image}}</code> helper with <code>{{primary_author.cover_image}}</code> or <code>{{authors.[#].cover_image}}</code>',
-        details: `The usage of <code>{{author.cover_image}}</code> is no longer valid and should be replaced with either <code>{{primary_author.cover_image}}</code>
+        details: `The usage of <code>{{author.cover_image}}</code> is deprecated and should be replaced with either <code>{{primary_author.cover_image}}</code>
         or <code>{{authors.[#].cover_image}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.cover_image\s*?}}/g,
@@ -205,7 +205,7 @@ rules = {
     'GS001-DEPR-AUTH-URL': {
         level: 'error',
         rule: 'Replace the <code>{{author.url}}</code> helper with <code>{{primary_author.url}}</code> or <code>{{authors.[#].url}}</code>',
-        details: `The usage of <code>{{author.url}}</code> is no longer valid and should be replaced with either <code>{{primary_author.url}}</code>
+        details: `The usage of <code>{{author.url}}</code> is deprecated and should be replaced with either <code>{{primary_author.url}}</code>
         or <code>{{authors.[#].url}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?author\.url\s*?}}/g,
@@ -214,7 +214,7 @@ rules = {
     'GS001-DEPR-PAUTH': {
         level: 'error',
         rule: 'Replace the <code>{{post.author}}</code> helper with <code>{{post.primary_author}}</code> or <code>{{authors.[#]}}</code>',
-        details: `The usage of <code>{{post.author}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author}}</code>
+        details: `The usage of <code>{{post.author}}</code> is deprecated and should be replaced with either <code>{{post.primary_author}}</code>
         or <code>{{post.authors.[#]}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\s*?}}/g,
@@ -223,7 +223,7 @@ rules = {
     'GS001-DEPR-PAUTH-ID': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.id}}</code> helper with <code>{{post.primary_author.id}}</code> or <code>{{authors.[#].id}}</code>',
-        details: `The usage of <code>{{post.author.id}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.id}}</code>
+        details: `The usage of <code>{{post.author.id}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.id}}</code>
         or <code>{{post.authors.[#].id}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.id\s*?}}/g,
@@ -232,7 +232,7 @@ rules = {
     'GS001-DEPR-PAUTH-SLUG': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.slug}}</code> helper with <code>{{post.primary_author.slug}}</code> or <code>{{post.authors.[#].slug}}</code>',
-        details: `The usage of <code>{{post.author.slug}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.slug}}</code>
+        details: `The usage of <code>{{post.author.slug}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.slug}}</code>
         or <code>{{post.authors.[#].slug}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.slug\s*?}}/g,
@@ -241,7 +241,7 @@ rules = {
     'GS001-DEPR-PAUTH-MAIL': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.email}}</code> helper with <code>{{post.primary_author.email}}</code> or <code>{{post.authors.[#].email}}</code>',
-        details: `The usage of <code>{{post.author.email}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.email}}</code>
+        details: `The usage of <code>{{post.author.email}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.email}}</code>
         or <code>{{post.authors.[#].email}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.email\s*?}}/g,
@@ -250,7 +250,7 @@ rules = {
     'GS001-DEPR-PAUTH-MT': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.meta_title}}</code> helper with <code>{{post.primary_author.meta_title}}</code> or <code>{{post.authors.[#].meta_title}}</code>',
-        details: `The usage of <code>{{post.author.meta_title}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.meta_title}}</code>
+        details: `The usage of <code>{{post.author.meta_title}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.meta_title}}</code>
         or <code>{{post.authors.[#].meta_title}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.meta_title\s*?}}/g,
@@ -259,7 +259,7 @@ rules = {
     'GS001-DEPR-PAUTH-MD': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.meta_description}}</code> helper with <code>{{post.primary_author.meta_description}}</code> or <code>{{post.authors.[#].meta_description}}</code>',
-        details: `The usage of <code>{{post.author.meta_description}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.meta_description}}</code>
+        details: `The usage of <code>{{post.author.meta_description}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.meta_description}}</code>
         or <code>{{post.authors.[#].meta_description}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.meta_description\s*?}}/g,
@@ -268,7 +268,7 @@ rules = {
     'GS001-DEPR-PAUTH-NAME': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.name}}</code> helper with <code>{{post.primary_author.name}}</code> or <code>{{post.authors.[#].name}}</code>',
-        details: `The usage of <code>{{post.author.name}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.name}}</code>
+        details: `The usage of <code>{{post.author.name}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.name}}</code>
         or <code>{{post.authors.[#].name}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.name\s*?}}/g,
@@ -277,7 +277,7 @@ rules = {
     'GS001-DEPR-PAUTH-BIO': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.bio}}</code> helper with <code>{{post.primary_author.bio}}</code> or <code>{{post.authors.[#].bio}}</code>',
-        details: `The usage of <code>{{post.author.bio}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.bio}}</code>
+        details: `The usage of <code>{{post.author.bio}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.bio}}</code>
         or <code>{{post.authors.[#].bio}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.bio\s*?}}/g,
@@ -286,7 +286,7 @@ rules = {
     'GS001-DEPR-PAUTH-LOC': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.location}}</code> helper with <code>{{post.primary_author.location}}</code> or <code>{{post.authors.[#].location}}</code>',
-        details: `The usage of <code>{{post.author.location}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.location}}</code>
+        details: `The usage of <code>{{post.author.location}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.location}}</code>
         or <code>{{post.authors.[#].location}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.location\s*?}}/g,
@@ -295,7 +295,7 @@ rules = {
     'GS001-DEPR-PAUTH-WEB': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.website}}</code> helper with <code>{{post.primary_author.website}}</code> or <code>{{post.authors.[#].website}}</code>',
-        details: `The usage of <code>{{post.author.website}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.website}}</code>
+        details: `The usage of <code>{{post.author.website}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.website}}</code>
         or <code>{{post.authors.[#].website}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.website\s*?}}/g,
@@ -304,7 +304,7 @@ rules = {
     'GS001-DEPR-PAUTH-TW': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.twitter}}</code> helper with <code>{{post.primary_author.twitter}}</code> or <code>{{post.authors.[#].twitter}}</code>',
-        details: `The usage of <code>{{post.author.twitter}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.twitter}}</code>
+        details: `The usage of <code>{{post.author.twitter}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.twitter}}</code>
         or <code>{{post.authors.[#].twitter}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.twitter\s*?}}/g,
@@ -313,7 +313,7 @@ rules = {
     'GS001-DEPR-PAUTH-FB': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.facebook}}</code> helper with <code>{{post.primary_author.facebook}}</code> or <code>{{post.authors.[#].facebook}}</code>',
-        details: `The usage of <code>{{post.author.facebook}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.facebook}}</code>
+        details: `The usage of <code>{{post.author.facebook}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.facebook}}</code>
         or <code>{{post.authors.[#].facebook}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.facebook\s*?}}/g,
@@ -322,7 +322,7 @@ rules = {
     'GS001-DEPR-PAUTH-PIMG': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.profile_image}}</code> helper with <code>{{post.primary_author.profile_image}}</code> or <code>{{post.authors.[#].profile_image}}</code>',
-        details: `The usage of <code>{{post.author.profile_image}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.profile_image}}</code>
+        details: `The usage of <code>{{post.author.profile_image}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.profile_image}}</code>
         or <code>{{post.authors.[#].profile_image}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.profile_image\s*?}}/g,
@@ -331,7 +331,7 @@ rules = {
     'GS001-DEPR-PAUTH-CIMG': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.cover_image}}</code> helper with <code>{{post.primary_author.cover_image}}</code> or <code>{{post.authors.[#].cover_image}}</code>',
-        details: `The usage of <code>{{post.author.cover_image}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.cover_image}}</code>
+        details: `The usage of <code>{{post.author.cover_image}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.cover_image}}</code>
         or <code>{{post.authors.[#].cover_image}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.cover_image\s*?}}/g,
@@ -340,7 +340,7 @@ rules = {
     'GS001-DEPR-PAUTH-URL': {
         level: 'error',
         rule: 'Replace the <code>{{post.author.url}}</code> helper with <code>{{post.primary_author.url}}</code> or <code>{{post.authors.[#].url}}</code>',
-        details: `The usage of <code>{{post.author.url}}</code> is no longer valid and should be replaced with either <code>{{post.primary_author.url}}</code>
+        details: `The usage of <code>{{post.author.url}}</code> is deprecated and should be replaced with either <code>{{post.primary_author.url}}</code>
         or <code>{{post.authors.[#].url}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?post\.author\.url\s*?}}/g,
@@ -349,7 +349,7 @@ rules = {
     'GS001-DEPR-NAUTH': {
         level: 'error',
         rule: 'Replace <code>../author</code> with <code>../primary_author</code> or <code>../authors.[#]</code>',
-        details: `The usage of <code>../author</code> is no longer valid and should be replaced with either <code>../primary_author</code>
+        details: `The usage of <code>../author</code> is deprecated and should be replaced with either <code>../primary_author</code>
         or <code>../authors.[#]</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?(?:#|#if)?\s*?\.\.\/author(?:\.\S*?)?\s*?}}/g,
@@ -358,7 +358,7 @@ rules = {
     'GS001-DEPR-IUA': {
         level: 'error',
         rule: 'Replace <code>{{img_url author.*}}</code> with <code>{{img_url primary_author.*}}</code> or <code>.{img_url author.[#].*}}</code>',
-        details: `The usage of <code>{{img_url author.*}}</code> is no longer valid and should be replaced with either <code>{{img_url primary_author.*}}</code>
+        details: `The usage of <code>{{img_url author.*}}</code> is deprecated and should be replaced with either <code>{{img_url primary_author.*}}</code>
         or <code>{{img_url author.[#].*}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}authors" target=_blank>here</a>.`,
         regex: /{{\s*?img_url\s*?(author.).*}}/g,
@@ -368,7 +368,7 @@ rules = {
     'GS001-DEPR-ESC': {
         level: 'error',
         rule: 'Replace <code>{{error.statusCode}}</code> with <code>{{error.code}}</code>',
-        details: `The usage of <code>{{error.statusCode}}</code> is no longer valid and should be replaced with <code>{{error.code}}</code>.<br>
+        details: `The usage of <code>{{error.statusCode}}</code> is deprecated and should be replaced with <code>{{error.code}}</code>.<br>
         When in <code>error</code> context, e. g. in the <code>error.hbs</code> template, replace <code>{{statusCode}}</code> with <code>{{code}}</code>.<br>
         Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}templates#section-error-hbs" target=_blank>here</a>.`,
         regex: /{{\s*?(?:error\.)?(statusCode)\s*?}}/g,

--- a/test/fixtures/themes/001-deprecations/v1/invalid/post.hbs
+++ b/test/fixtures/themes/001-deprecations/v1/invalid/post.hbs
@@ -38,3 +38,5 @@
         {{cover}}
     {{/if}}
 {{/author}}
+
+{{author}}


### PR DESCRIPTION
no issue

- {{author}} is an output helper and it should be replaced with {{authors}} (not with {{primary_author}}, because this is not an output helper, it's an object)
- {{#author}}{{/author}} should be replaced with {{#primary_author}} or {{#foreach authors}}..
- update rule texts to use "is deprecated" instead of "is not valid anymore"