### PR TITLE
🐛 Fixed Koenig CSS detection in non-CSS files

### DIFF
--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -19,21 +19,12 @@ checkKoenigCssClasses = function checkKoenigCssClasses(theme, options, themePath
     });
 
     _.each(ruleSet, function (check, ruleCode) {
-        let cssFiles = [];
-
-        // Get all CSS files
-        _.each(theme.files, function (themeFile) {
-            if (themeFile.file.match(/\.css/)) {
-                cssFiles.push(themeFile);
-            }
-        });
-
-        if (cssFiles.length) {
+        if (theme.files) {
             // Cheeck CSS files for presence of the classes
-            _.each(cssFiles, function (cssFile) {
+            _.each(theme.files, function (themeFile) {
                 try {
-                    cssFile = fs.readFileSync(path.join(themePath, cssFile.file), 'utf8');
-                    let cssPresent = cssFile.match(check.regex);
+                    themeFile = fs.readFileSync(path.join(themePath, themeFile.file), 'utf8');
+                    let cssPresent = themeFile.match(check.regex);
 
                     if (cssPresent && theme.results.pass.indexOf(ruleCode) === -1) {
                         theme.results.pass.push(ruleCode);
@@ -44,7 +35,7 @@ checkKoenigCssClasses = function checkKoenigCssClasses(theme, options, themePath
             });
         }
 
-        if (!cssFiles || (theme.results.pass.indexOf(ruleCode) === -1 && !theme.results.fail.hasOwnProperty(ruleCode))) {
+        if (!theme.files || (theme.results.pass.indexOf(ruleCode) === -1 && !theme.results.fail.hasOwnProperty(ruleCode))) {
             theme.results.fail[ruleCode] = {};
             theme.results.fail[ruleCode].failures = [
                 {

--- a/test/fixtures/themes/050-koenig-css-classes/mixed/assets/my.css
+++ b/test/fixtures/themes/050-koenig-css-classes/mixed/assets/my.css
@@ -1,1 +1,1 @@
-.kg-width-wide {}
+.kg-width {}

--- a/test/fixtures/themes/050-koenig-css-classes/mixed/default.hbs
+++ b/test/fixtures/themes/050-koenig-css-classes/mixed/default.hbs
@@ -1,4 +1,8 @@
 <html>
+{{!-- Detect CSS classes in hbs files --}}
+<style>
+    .kg-width-wide {}
+</style>
 <head>
     <title>Test Theme</title>
 </head>


### PR DESCRIPTION
closes #152

- Scan through every file to find required Koenig CSS classes instead of `*.css` files only
- Udated test to proof detection