### PR TITLE
🐛 Fixed GScan performance

### DIFF
--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -22,7 +22,7 @@ checkKoenigCssClasses = function checkKoenigCssClasses(theme, options, themePath
         if (theme.files) {
             // Check CSS files and HBS files for presence of the classes
             _.each(theme.files, function (themeFile) {
-                if (['.css', '.hbs'].indexOf(themeFile.ext) === -1) {
+                if (!['.css', '.hbs'].includes(themeFile.ext)) {
                     return;
                 }
 

--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -20,8 +20,12 @@ checkKoenigCssClasses = function checkKoenigCssClasses(theme, options, themePath
 
     _.each(ruleSet, function (check, ruleCode) {
         if (theme.files) {
-            // Cheeck CSS files for presence of the classes
+            // Check CSS files and HBS files for presence of the classes
             _.each(theme.files, function (themeFile) {
+                if (['.css', '.hbs'].indexOf(themeFile.ext) === -1) {
+                    return;
+                }
+
                 try {
                     themeFile = fs.readFileSync(path.join(themePath, themeFile.file), 'utf8');
                     let cssPresent = themeFile.match(check.regex);

--- a/test/050-koenig-css-classes.test.js
+++ b/test/050-koenig-css-classes.test.js
@@ -67,7 +67,7 @@ describe('050 Koenig CSS classes', function () {
             }).catch(done);
         });
 
-        it('[failure] should invalidate theme when three CSS classes are missing', function (done) {
+        it('[failure] should invalidate theme when three CSS classes are missing (classes are spread in hbs and css files)', function (done) {
             utils.testCheck(thisCheck, '050-koenig-css-classes/mixed').then(function (output) {
                 output.should.be.a.ValidThemeObject();
 


### PR DESCRIPTION
closes #159

- the checker read any asset from disk
- added restriction for .hbs and .css files