### PR TITLE
Add Dockerfile for building an image on node 10

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules/
+*.log
+.git*
+.npmignore
+.travis.yml
+circle.yml
+.dockerignore
+Dockerfile
+nodemon.json
+shipitfile.js

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,5 @@ test/**
 .travis.yml
 Gruntfile.js
 node_modules/**
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:10-alpine
 
+ENV NODE_ENV development
+
 # Set port to run application on
 ENV port 2369
 
@@ -16,7 +18,7 @@ COPY . /usr/src/app
 # Run tests at build time and make sure we clean up unused packages and caches
 RUN yarn install && yarn test \
     && yarn install --production && yarn cache clean \
-    && chown -R $user:$user /usr/src/app
+    && chown -R $user:$user /usr/src/app && rm -rf config.*.json
 
 USER $user
 EXPOSE $port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:10-alpine
+
+# Set port to run application on
+ENV port 2369
+
+# Create a non-root user to run as
+ENV user app
+ENV uid 1001
+
+RUN addgroup -g $uid -S $user && adduser -u $uid -S -G $user $user \
+    && mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+# Run tests at build time and make sure we clean up unused packages and caches
+RUN yarn install && yarn test \
+    && yarn install --production && yarn cache clean \
+    && chown -R $user:$user /usr/src/app
+
+USER $user
+EXPOSE $port
+
+CMD yarn start

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -6,7 +6,7 @@ function init(shipit) {
             yarn: true,
             workspace: './',
             deployTo: '/opt/gscan/',
-            ignores: ['.git', '.gitkeep', '.gitignore', '.eslintrc.js', '.eslintcache', 'node_modules', '/test', '/app/public/.eslintrc.js']
+            ignores: ['.git', '.gitkeep', '.gitignore', '.eslintrc.js', '.eslintcache', 'node_modules', '/test', '/app/public/.eslintrc.js', 'Dockerfile', '.dockerignore']
         },
         staging: {
             servers: process.env.STG_USER + '@' + process.env.STG_SERVER,


### PR DESCRIPTION
Hi,

At some point in the near future I'd like to run gscan and some of our other services on docker and maybe even Kubernetes.

This PR adds a Dockerfile for building gscan as a container image.

To try this out, checkout this branch.

### Build the image
```
docker build -t gscan .
```

### Run the image locally
```
docker run -it -p 2369:2369 gscan:latest
```

Overriding the port that gscan runs on:
```
docker run -it -e port=8080 -p 8080:8080 gscan:latest
```