### PR TITLE
🛠 Ported cli to use pretty-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@tryghost/extract-zip": "1.6.6",
+    "@tryghost/pretty-cli": "1.2.1",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.1",
     "commander": "2.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,14 @@
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
+"@tryghost/pretty-cli@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-cli/-/pretty-cli-1.2.1.tgz#b419e936c81c8aabf7f081645751c17004a5bb09"
+  integrity sha512-SFu5CcljG7mqxcA/J2WFE9M/bbpzJG0oVqT7P/P0HRbcTgBmQ5nMczO70WNASSqBglAh/uR34K0HVz5qynxyDw==
+  dependencies:
+    chalk "^2.4.1"
+    sywac "^1.2.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -437,7 +445,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -3526,6 +3534,11 @@ supports-color@^5.2.0, supports-color@^5.3.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+sywac@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sywac/-/sywac-1.2.1.tgz#528e482b2f2a18e764ffccc59eb40eea16a7f97d"
+  integrity sha512-bf8agjBAV9mm90k2nWoobe48bO/XugTS86W4dGYTpzVlfFv1cmWsRrQ9hUKIfoDaIRaXIta/BLFINmmxfV+otg==
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
closes #177

@ErisDS one thing that bothers me with new output for usage:
```
Usage:
  gscan <themePath> [options]

Arguments:
  <themePath>  Theme folder or .zip file path                                    [required] [string]

Global Options:
  -h, --help     Show help                                                [commands: help] [boolean]
  -v, --version  Show version number                                   [commands: version] [boolean]

Options:
  -p, --pre  Run a pre-check only                                                          [boolean]
  -z, --zip  Theme path points to a zip file                                               [boolean]
  -1, --v1   Check theme for Ghost 1.0 compatibility, instead of 2.0                       [boolean]
```
is that `Options:` part, that the user would be most interested in, is listed in the very end of the output. Haven't found a good way to override that in `sywac` (other than listing everything in `positional(...)` configuration), maybe you know a way?