### PR TITLE
✨ Added rule in canary set for ghost-api=v0.1 detection

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -30,7 +30,7 @@ const v2PackageJSONValidationRules = _.extend({},
 const canaryPackageJSONConditionalRules = {};
 const canaryPackageJSONValidationRules = _.extend({},
     {isPresentEngineGhostAPI: 'GS010-PJ-GHOST-API'},
-    {isv1EngineGhostAPI: 'GS010-PJ-GHOST-API-V1'},
+    {isv01EngineGhostAPI: 'GS010-PJ-GHOST-API-V01'},
     canaryPackageJSONConditionalRules
 );
 

--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -94,9 +94,16 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
     }
 
     if (packageJSON.engines && packageJSON.engines['ghost-api']) {
-        // TODO: add more coersion cases for 0.1
-        if (packageJSON.engines['ghost-api'] === 'v0.1') {
-            markFailed('isv1EngineGhostAPI');
+        // NOTE: checks for same versions as were available in Ghost 2.0 (v0.1, ^0.1 etc.)
+        //      ref.: https://github.com/TryGhost/Ghost/blob/bc41550/core/frontend/services/themes/engines/create.js#L10-L16
+        const coerced = semver.coerce(packageJSON.engines['ghost-api']);
+
+        if (coerced !== null) {
+            const major = semver(semver(coerced).version).major;
+
+            if (major === 0) {
+                markFailed('isv01EngineGhostAPI');
+            }
         }
     }
 

--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -30,6 +30,7 @@ const v2PackageJSONValidationRules = _.extend({},
 const canaryPackageJSONConditionalRules = {};
 const canaryPackageJSONValidationRules = _.extend({},
     {isPresentEngineGhostAPI: 'GS010-PJ-GHOST-API'},
+    {isv1EngineGhostAPI: 'GS010-PJ-GHOST-API-V1'},
     canaryPackageJSONConditionalRules
 );
 
@@ -90,6 +91,13 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
 
     if (!packageJSON.engines || !packageJSON.engines['ghost-api']) {
         markFailed('isPresentEngineGhostAPI');
+    }
+
+    if (packageJSON.engines && packageJSON.engines['ghost-api']) {
+        // TODO: add more coersion cases for 0.1
+        if (packageJSON.engines['ghost-api'] === 'v0.1') {
+            markFailed('isv1EngineGhostAPI');
+        }
     }
 
     const failedRules = _private.getFailedRules(failed);

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -22,7 +22,7 @@ let rules = {
         If no <code>"ghost-api"</code> property is provided, Ghost will use its default setting of "v3" Ghost API.<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
-    'GS010-PJ-GHOST-API-V1': {
+    'GS010-PJ-GHOST-API-V01': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is incompatible with current version of Ghost API and will fall back to "v3"',
         details: oneLineTrim`Please change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -21,6 +21,13 @@ let rules = {
         details: oneLineTrim`Please add <code>"ghost-api"</code> to your <code>package.json</code>. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>
         If no <code>"ghost-api"</code> property is provided, Ghost will use its default setting of "v3" Ghost API.<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
+    },
+    'GS010-PJ-GHOST-API-V1': {
+        level: 'error',
+        rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is incompatible with current version of Ghost API and will fall back to "v3"',
+        details: oneLineTrim`Please change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>
+        If <code>"ghost-api"</code> property is left at "v0.1", Ghost will use its default setting of "v3".<br>
+        Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
     }
 };
 

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -309,7 +309,7 @@ describe('010 package.json', function () {
                     'GS010-PJ-CONF-PPP-INT',
                     'GS010-PJ-KEYWORDS',
                     'GS010-PJ-GHOST-API',
-                    'GS010-PJ-GHOST-API-V1'
+                    'GS010-PJ-GHOST-API-V01'
                 ]);
 
                 theme.results.fail.should.be.an.Object().which.is.empty();
@@ -353,7 +353,7 @@ describe('010 package.json', function () {
                 theme.results.pass.should.eql([
                     'GS010-PJ-REQ',
                     'GS010-PJ-PARSE',
-                    'GS010-PJ-GHOST-API-V1'
+                    'GS010-PJ-GHOST-API-V01'
                 ]);
 
                 theme.results.fail.should.be.an.Object().with.keys(

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -308,7 +308,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CONF-PPP',
                     'GS010-PJ-CONF-PPP-INT',
                     'GS010-PJ-KEYWORDS',
-                    'GS010-PJ-GHOST-API'
+                    'GS010-PJ-GHOST-API',
+                    'GS010-PJ-GHOST-API-V1'
                 ]);
 
                 theme.results.fail.should.be.an.Object().which.is.empty();
@@ -326,7 +327,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-NAME-REQ',
                     'GS010-PJ-VERSION-REQ',
                     'GS010-PJ-AUT-EM-REQ',
-                    'GS010-PJ-CONF-PPP'
+                    'GS010-PJ-CONF-PPP',
+                    'GS010-PJ-GHOST-API'
                 ]);
 
                 theme.results.fail.should.be.an.Object().with.keys(
@@ -350,7 +352,8 @@ describe('010 package.json', function () {
 
                 theme.results.pass.should.eql([
                     'GS010-PJ-REQ',
-                    'GS010-PJ-PARSE'
+                    'GS010-PJ-PARSE',
+                    'GS010-PJ-GHOST-API-V1'
                 ]);
 
                 theme.results.fail.should.be.an.Object().with.keys(

--- a/test/fixtures/themes/010-packagejson/fields-are-invalid/package.json
+++ b/test/fixtures/themes/010-packagejson/fields-are-invalid/package.json
@@ -5,6 +5,9 @@
     "email": "something"
   },
   "keywords": "ghost-theme",
+  "engines": {
+    "ghost-api": "v0.1"
+  },
   "config": {
     "posts_per_page": "something"
   }


### PR DESCRIPTION
refs #144

TODO: 
- [x] clarify the use case. do we want to detect only `v1` or any other incompatible version in `ghost-api`?
  - A: only detect v0.1 detection
- [x] change rule wording according to the decision above