### PR TITLE
💡️Corrected error.statusCode rule to deprecate error.code instead

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -28,6 +28,16 @@ let rules = {
         details: oneLineTrim`Please change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>
         If <code>"ghost-api"</code> property is left at "v0.1", Ghost will use its default setting of "v3".<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
+    },
+    // Updated v2 rules
+    'GS001-DEPR-ESC': {
+        level: 'error',
+        rule: 'Replace <code>{{error.code}}</code> with <code>{{error.statusCode}}</code>',
+        details: oneLineTrim`The usage of <code>{{error.code}}</code> is deprecated and should be replaced with <code>{{error.statusCode}}</code>.<br>
+        When in <code>error</code> context, e. g. in the <code>error.hbs</code> template, replace <code>{{code}}</code> with <code>{{statusCode}}</code>.<br>
+        Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}structure/#errorhbs" target=_blank>here</a>.`,
+        regex: /{{\s*?(?:error\.)?(code)\s*?}}/g,
+        helper: '{{error.code}}'
     }
 };
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -1189,7 +1189,7 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-IUA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IUA'].failures.length.should.eql(1);
 
-                // {{error.statusCode}}
+                // {{error.code}} / {{code}}
                 output.results.fail['GS001-DEPR-ESC'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-ESC'].failures.length.should.eql(2);
 

--- a/test/fixtures/themes/001-deprecations/canary/invalid/default.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/invalid/default.hbs
@@ -22,7 +22,7 @@
     {{author_profile_image}}
 
     {{#if error}}
-        {{error.statusCode}}
+        {{error.code}}
     {{/if}}
 
     {{#each}}

--- a/test/fixtures/themes/001-deprecations/canary/invalid/error.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/invalid/error.hbs
@@ -1,1 +1,1 @@
-{{statusCode}}
+{{code}}

--- a/test/fixtures/themes/001-deprecations/canary/invalid_all/default.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/invalid_all/default.hbs
@@ -32,7 +32,7 @@
     {{author_image}}
 
     {{#if error}}
-        {{error.statusCode}}
+        {{error.code}}
     {{/if}}
 
      {{#each}}

--- a/test/fixtures/themes/001-deprecations/canary/invalid_all/error.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/invalid_all/error.hbs
@@ -1,1 +1,1 @@
-{{statusCode}}
+{{code}}

--- a/test/fixtures/themes/001-deprecations/canary/valid/default.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/valid/default.hbs
@@ -13,7 +13,7 @@
 
     {{#get "posts" include="tags,authors" filter="authors:{{primary_author.slug}}+id:-{{id}}" fields="authors"}}
         {{#foreach posts}}
-            {{title}} 
+            {{title}}
         {{/foreach}}
     {{/get}}
 
@@ -21,7 +21,7 @@
     {{author_profile_image}}
 
     {{authors[0].cover}}
-    {{error.code}}
+    {{error.statusCode}}
 </body>
     {{ghost_foot}}
 </html>

--- a/test/fixtures/themes/001-deprecations/canary/valid/error.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/valid/error.hbs
@@ -1,1 +1,1 @@
-{{code}}
+{{statusCode}}


### PR DESCRIPTION
refs https://github.com/TryGhost/gscan/issues/144
refs https://github.com/TryGhost/gscan/issues/137

- Overridden GS001-DEPR-ESC v2 rule in canary set
- The original {{statusCode}} deprecation (#137) was a mistake and what was meant to be deprecated is {{code}} (ref. https://github.com/TryGhost/Ghost/pull/9144/files#diff-6b41d6f0ef148f7d202931a87d5c4130R85)
- `statusCode` was meant to be used everywhere similarly to this change - https://github.com/TryGhost/Ghost/commit/02199c6b02589b12324d8191c69ea80aad6b907a