### PR TITLE
✨ Added Koenig bookmark card CSS v2 rules 

### DIFF
--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -528,7 +528,7 @@ let rules = {
     'GS050-CSS-KGBMTI': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-title</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-title</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-title</code> CSS class is required otherwise the bookmark card title will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-title/g,
         className: '.kg-bookmark-title',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -546,7 +546,7 @@ let rules = {
     'GS050-CSS-KGBMME': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-metadata</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-metadata</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-metadata</code> CSS class is required otherwise the bookmark card meta details will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-metadata/g,
         className: '.kg-bookmark-metadata',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -498,6 +498,96 @@ let rules = {
         className: '.kg-gallery-image',
         css: true
     },
+    'GS050-CSS-KGBM': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-card</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-card/g,
+        className: '.kg-bookmark-card',
+        css: true
+    },
+    'GS050-CSS-KGBMCO': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-container</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-container/g,
+        className: '.kg-bookmark-container',
+        css: true
+    },
+    'GS050-CSS-KGBMCON': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-content</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-content</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-content/g,
+        className: '.kg-bookmark-content',
+        css: true
+    },
+    'GS050-CSS-KGBMTI': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-title</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-title</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-title/g,
+        className: '.kg-bookmark-title',
+        css: true
+    },
+    'GS050-CSS-KGBMDE': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-description</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-description</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-description/g,
+        className: '.kg-bookmark-description',
+        css: true
+    },
+    'GS050-CSS-KGBMME': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-metadata</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-metadata</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-metadata/g,
+        className: '.kg-bookmark-metadata',
+        css: true
+    },
+    'GS050-CSS-KGBMIC': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-icon</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-icon</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-icon/g,
+        className: '.kg-bookmark-icon',
+        css: true
+    },
+    'GS050-CSS-KGBMAU': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-author</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-author</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-author/g,
+        className: '.kg-bookmark-author',
+        css: true
+    },
+    'GS050-CSS-KGBMPU': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-publisher</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-publisher</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-publisher/g,
+        className: '.kg-bookmark-publisher',
+        css: true
+    },
+    'GS050-CSS-KGBMTH': {
+        level: 'error',
+        rule: 'The <code>.kg-bookmark-thumbnail</code> CSS class is required to appear styled in your theme',
+        details: oneLineTrim`The <code>.kg-bookmark-thumbnail</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
+        regex: /\.kg-bookmark-thumbnail/g,
+        className: '.kg-bookmark-thumbnail',
+        css: true
+    },
     // Updated v1 rules
     'GS001-DEPR-AC': {
         rule: 'Replace the <code>{{author.cover}}</code> helper with <code>{{primary_author.cover_image}}</code>',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -537,7 +537,7 @@ let rules = {
     'GS050-CSS-KGBMDE': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-description</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-description</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-description</code> CSS class is required otherwise the bookmark card description will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-description/g,
         className: '.kg-bookmark-description',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -573,7 +573,7 @@ let rules = {
     'GS050-CSS-KGBMPU': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-publisher</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-publisher</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-publisher</code> CSS class is required otherwise the bookmark card publisher name will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-publisher/g,
         className: '.kg-bookmark-publisher',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -564,7 +564,7 @@ let rules = {
     'GS050-CSS-KGBMAU': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-author</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-author</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-author</code> CSS class is required otherwise the bookmark card author name will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-author/g,
         className: '.kg-bookmark-author',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -555,7 +555,7 @@ let rules = {
     'GS050-CSS-KGBMIC': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-icon</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-icon</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-icon</code> CSS class is required otherwise the bookmark card author icon will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-icon/g,
         className: '.kg-bookmark-icon',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -519,7 +519,7 @@ let rules = {
     'GS050-CSS-KGBMCON': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-content</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-content</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-content</code> CSS class is required otherwise the bookmark card main content will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-content/g,
         className: '.kg-bookmark-content',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -582,7 +582,7 @@ let rules = {
     'GS050-CSS-KGBMTH': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-thumbnail</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-thumbnail</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-thumbnail</code> CSS class is required otherwise the bookmark card thumbnail image will appear unstyled.
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-thumbnail/g,
         className: '.kg-bookmark-thumbnail',

--- a/test/050-koenig-css-classes.test.js
+++ b/test/050-koenig-css-classes.test.js
@@ -87,7 +87,7 @@ describe('050 Koenig CSS classes', function () {
             utils.testCheck(thisCheck, '050-koenig-css-classes/valid').then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
-                output.results.pass.should.be.an.Array().with.lengthOf(5);
+                output.results.pass.should.be.an.Array().with.lengthOf(15);
 
                 output.results.fail.should.be.an.Object().which.is.empty();
 
@@ -167,7 +167,7 @@ describe('050 Koenig CSS classes', function () {
             utils.testCheck(thisCheck, '050-koenig-css-classes/valid', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
-                output.results.pass.should.be.an.Array().with.lengthOf(5);
+                output.results.pass.should.be.an.Array().with.lengthOf(15);
 
                 output.results.fail.should.be.an.Object().which.is.empty();
 

--- a/test/fixtures/themes/050-koenig-css-classes/valid/assets/my.css
+++ b/test/fixtures/themes/050-koenig-css-classes/valid/assets/my.css
@@ -4,3 +4,14 @@
 .kg-gallery-container {}
 .kg-gallery-row {}
 .kg-gallery-image {}
+
+.kg-bookmark-card {}
+.kg-bookmark-container {}
+.kg-bookmark-content {}
+.kg-bookmark-title {}
+.kg-bookmark-description {}
+.kg-bookmark-metadata {}
+.kg-bookmark-icon {}
+.kg-bookmark-author {}
+.kg-bookmark-publisher {}
+.kg-bookmark-thumbnail {}

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -552,7 +552,7 @@ describe('format', function () {
         checker(themePath('005-compile/invalid')).then((theme) => {
             theme = format(theme);
 
-            theme.results.error.length.should.eql(16);
+            theme.results.error.length.should.eql(26);
             theme.results.error[0].fatal.should.eql(true);
             // theme.results.error[1].fatal.should.eql(true);
             // theme.results.error[2].fatal.should.eql(true);
@@ -590,7 +590,7 @@ describe('format', function () {
             theme.results.warning.all.length.should.eql(3);
             theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
 
-            theme.results.error.all.length.should.eql(16);
+            theme.results.error.all.length.should.eql(26);
 
             // 1 rule has file references
             theme.results.error.byFiles['author.hbs'].length.should.eql(1);
@@ -612,7 +612,7 @@ describe('format', function () {
             theme.results.recommendation.all.length.should.eql(2);
             theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
-            theme.results.error.all.length.should.eql(88);
+            theme.results.error.all.length.should.eql(98);
             theme.results.warning.all.length.should.eql(5);
 
             theme.results.error.byFiles['assets/my.css'].length.should.eql(3);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/11024

- 10 bookmark card rules have landed in Ghost as of 2.30.0 release, so they need to be checked for in v2 onwards

@kevinansfield would appreciate if you could double-check if all needed styles are correct.

@daviddarnes lets colab on the words used in these rules :dancer: will also apply similar wording to other CSS rules.
Things to keep in mind for wording:
- should not be Ghost version specific (e.g. use Ghsot 2.0)
- say exactly what will break