### PR TITLE
Removed missleading rule for {{statuscode}} in v2 rules

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -29,7 +29,6 @@ let rules = {
         If <code>"ghost-api"</code> property is left at "v0.1", Ghost will use its default setting of "v3".<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
-    // Updated v2 rules
     'GS001-DEPR-ESC': {
         level: 'error',
         rule: 'Replace <code>{{error.code}}</code> with <code>{{error.statusCode}}</code>',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -380,15 +380,6 @@ let rules = {
         regex: /{{\s*?img_url\s*?(author.).*}}/g,
         helper: '{{img_url author.*}}'
     },
-    'GS001-DEPR-ESC': {
-        level: 'error',
-        rule: 'Replace <code>{{error.statusCode}}</code> with <code>{{error.code}}</code>',
-        details: oneLineTrim`The usage of <code>{{error.statusCode}}</code> is deprecated and should be replaced with <code>{{error.code}}</code>.<br>
-        When in <code>error</code> context, e. g. in the <code>error.hbs</code> template, replace <code>{{statusCode}}</code> with <code>{{code}}</code>.<br>
-        Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}structure/#errorhbs" target=_blank>here</a>.`,
-        regex: /{{\s*?(?:error\.)?(statusCode)\s*?}}/g,
-        helper: '{{error.statusCode}}'
-    },
     'GS001-DEPR-BLOG': {
         level: 'error',
         rule: 'The <code>{{@blog}}</code> helper should be replaced with <code>{{@site}}</code>',

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -246,7 +246,6 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-PAUTH-URL',
                     'GS001-DEPR-NAUTH',
                     'GS001-DEPR-IUA',
-                    'GS001-DEPR-ESC',
                     'GS001-DEPR-BPL',
                     'GS001-DEPR-SGH',
                     'GS001-DEPR-SGF',
@@ -506,10 +505,6 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-IUA'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-IUA'].failures.length.should.eql(1);
 
-                // {{error.statusCode}}
-                output.results.fail['GS001-DEPR-ESC'].should.be.a.ValidFailObject();
-                output.results.fail['GS001-DEPR-ESC'].failures.length.should.eql(2);
-
                 // {{@blog}}
                 output.results.fail['GS001-DEPR-BLOG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BLOG'].failures.length.should.eql(2);
@@ -590,7 +585,6 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-NAUTH',
                     'GS001-DEPR-IUA',
                     'GS001-DEPR-AIMG-2',
-                    'GS001-DEPR-ESC',
                     'GS001-DEPR-BLOG',
                     'GS001-DEPR-BPL',
                     'GS001-DEPR-SPL',
@@ -759,10 +753,6 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-AIMG-2'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AIMG-2'].failures.length.should.eql(1);
 
-                // {{error.statusCode}}
-                output.results.fail['GS001-DEPR-ESC'].should.be.a.ValidFailObject();
-                output.results.fail['GS001-DEPR-ESC'].failures.length.should.eql(2);
-
                 // {{@blog.*}}
                 output.results.fail['GS001-DEPR-BLOG'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-BLOG'].failures.length.should.eql(1);
@@ -794,7 +784,7 @@ describe('001 Deprecations', function () {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().which.is.empty();
-                output.results.pass.should.be.an.Array().with.lengthOf(92);
+                output.results.pass.should.be.an.Array().with.lengthOf(91);
 
                 done();
             }).catch(done);
@@ -837,7 +827,6 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-PAUTH-LOC',
                     'GS001-DEPR-NAUTH',
                     'GS001-DEPR-IUA',
-                    'GS001-DEPR-ESC',
                     'GS001-DEPR-BPL',
                     'GS001-DEPR-BLOG'
                 );

--- a/test/fixtures/themes/001-deprecations/v2/invalid_all/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v2/invalid_all/default.hbs
@@ -32,7 +32,7 @@
     {{author_image}}
 
     {{#if error}}
-        {{error.statusCode}}
+        {{error.code}}
     {{/if}}
 
      {{#each}}

--- a/test/fixtures/themes/001-deprecations/v2/invalid_all/error.hbs
+++ b/test/fixtures/themes/001-deprecations/v2/invalid_all/error.hbs
@@ -1,1 +1,1 @@
-{{statusCode}}
+{{code}}

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -327,7 +327,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(97);
+            theme.results.pass.should.be.an.Array().with.lengthOf(96);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(
@@ -403,7 +403,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(97);
+            theme.results.pass.should.be.an.Array().with.lengthOf(96);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(
@@ -475,7 +475,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(97);
+            theme.results.pass.should.be.an.Array().with.lengthOf(96);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(
@@ -612,15 +612,14 @@ describe('format', function () {
             theme.results.recommendation.all.length.should.eql(2);
             theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
-            theme.results.error.all.length.should.eql(98);
+            theme.results.error.all.length.should.eql(97);
             theme.results.warning.all.length.should.eql(5);
 
             theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
-            theme.results.error.byFiles['default.hbs'].length.should.eql(17);
+            theme.results.error.byFiles['default.hbs'].length.should.eql(16);
             theme.results.error.byFiles['post.hbs'].length.should.eql(54);
             theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(5);
             theme.results.error.byFiles['index.hbs'].length.should.eql(9);
-            theme.results.error.byFiles['error.hbs'].length.should.eql(1);
 
             done();
         }).catch(done);


### PR DESCRIPTION
refs #144

- This rule was not meant to be there in the first place and might cause confusion for people who check if their v3 theme is running with Ghost v2 properly