### PR TITLE
🐛 Fixed default checks not being run on canary rules

### DIFF
--- a/lib/specs/index.js
+++ b/lib/specs/index.js
@@ -4,9 +4,7 @@ module.exports = {
     get: function get(key) {
         let [version] = key;
 
-        if (version === 'latest') {
-            version = 'v2';
-        } else if (version === 'v3') {
+        if (version === 'latest' || version === 'v3') {
             version = 'canary';
         }
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -175,8 +175,10 @@ describe('001 Deprecations', function () {
     });
 
     describe('v2 version:', function () {
+        const options = {checkVersion: 'v2'};
+
         it('[failure] theme is completely invalid', function (done) {
-            utils.testCheck(thisCheck, '001-deprecations/v2/invalid_all').then(function (output) {
+            utils.testCheck(thisCheck, '001-deprecations/v2/invalid_all', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().with.keys(
@@ -541,7 +543,7 @@ describe('001 Deprecations', function () {
         });
 
         it('[failure] theme is invalid', function (done) {
-            utils.testCheck(thisCheck, '001-deprecations/v2/invalid').then(function (output) {
+            utils.testCheck(thisCheck, '001-deprecations/v2/invalid', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().with.keys(
@@ -780,7 +782,7 @@ describe('001 Deprecations', function () {
         });
 
         it('[success] should show no error if no deprecated helpers used', function (done) {
-            utils.testCheck(thisCheck, '001-deprecations/v2/valid').then(function (output) {
+            utils.testCheck(thisCheck, '001-deprecations/v2/valid', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().which.is.empty();
@@ -791,7 +793,7 @@ describe('001 Deprecations', function () {
         });
 
         it('[mixed] should pass and fail when some rules pass and others fail', function (done) {
-            utils.testCheck(thisCheck, '001-deprecations/v2/mixed').then(function (output) {
+            utils.testCheck(thisCheck, '001-deprecations/v2/mixed', options).then(function (output) {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().with.keys(

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'testing';
 
 describe('Checker', function () {
     it('returns a valid theme when running all checks', function (done) {
-        checker(themePath('is-empty')).then((theme) => {
+        checker(themePath('is-empty'), {checkVersion: 'v2'}).then((theme) => {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
@@ -117,7 +117,7 @@ describe('Checker', function () {
     });
 
     it('checks for a v3 version if passed', function (done) {
-        checker(themePath('is-empty'), {checkVersion: 'canary'}).then((theme) => {
+        checker(themePath('is-empty'), {checkVersion: 'v3'}).then((theme) => {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
@@ -152,7 +152,7 @@ describe('Checker', function () {
         }).catch(done);
     });
 
-    it('checks for a latest version if passed', function (done) {
+    it('checks for a latest (v3) version if passed', function (done) {
         checker(themePath('is-empty'), {checkVersion: 'latest'}).then((theme) => {
             theme.should.be.a.ValidThemeObject();
 
@@ -161,7 +161,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(96);
+            theme.results.pass.should.be.an.Array().with.lengthOf(98);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(
@@ -187,7 +187,7 @@ describe('Checker', function () {
         }).catch(done);
     });
 
-    it('checks for a canary version if passed', function (done) {
+    it('checks for a canary (v3) version if passed', function (done) {
         checker(themePath('is-empty'), {checkVersion: 'canary'}).then((theme) => {
             theme.should.be.a.ValidThemeObject();
 

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -4,91 +4,187 @@ const checker = require('../lib/checker');
 const format = require('../lib/format');
 
 describe('Format', function () {
-    it('assert sorting in invalid theme', function (done) {
-        checker(themePath('005-compile/invalid')).then((theme) => {
-            theme = format(theme);
+    describe('v2', function () {
+        const options = {checkVersion: 'v2'};
 
-            theme.results.error.length.should.eql(26);
-            theme.results.error[0].fatal.should.eql(true);
-            // theme.results.error[1].fatal.should.eql(true);
-            // theme.results.error[2].fatal.should.eql(true);
-            theme.results.error[3].fatal.should.eql(false);
-            // theme.results.error[10].fatal.should.eql(false);
+        it('assert sorting in invalid theme', function (done) {
+            checker(themePath('005-compile/invalid'), options).then((theme) => {
+                theme = format(theme);
 
-            done();
-        }).catch(done);
+                theme.results.error.length.should.eql(26);
+                theme.results.error[0].fatal.should.eql(true);
+                // theme.results.error[1].fatal.should.eql(true);
+                // theme.results.error[2].fatal.should.eql(true);
+                theme.results.error[3].fatal.should.eql(false);
+                // theme.results.error[10].fatal.should.eql(false);
+
+                done();
+            }).catch(done);
+        });
+
+        it('assert sorting in empty theme', function (done) {
+            checker(themePath('is-empty'), options).then((theme) => {
+                theme = format(theme);
+
+                theme.results.error[0].fatal.should.eql(true);
+                theme.results.error[1].fatal.should.eql(true);
+                theme.results.error[4].fatal.should.eql(false);
+                theme.results.error[10].fatal.should.eql(false);
+                theme.results.error[11].fatal.should.eql(false);
+                theme.results.error[12].fatal.should.eql(false);
+
+                done();
+            }).catch(done);
+        });
+
+        it('sort by files for invalid theme', function (done) {
+            checker(themePath('005-compile/invalid'), options).then((theme) => {
+                theme = format(theme, {sortByFiles: true});
+
+                theme.results.hasFatalErrors.should.be.true();
+
+                theme.results.recommendation.all.length.should.eql(1);
+                theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+
+                theme.results.warning.all.length.should.eql(3);
+                theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
+
+                theme.results.error.all.length.should.eql(26);
+
+                // 1 rule has file references
+                theme.results.error.byFiles['author.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['page.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['post.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['index.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['package.json'].length.should.eql(9);
+
+                done();
+            }).catch(done);
+        });
+
+        it('sort by files for invalid_all theme', function (done) {
+            checker(themePath('001-deprecations/v2/invalid_all'), options).then((theme) => {
+                theme = format(theme, {sortByFiles: true});
+
+                theme.results.hasFatalErrors.should.be.true();
+
+                theme.results.recommendation.all.length.should.eql(2);
+                theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+
+                theme.results.error.all.length.should.eql(97);
+                theme.results.warning.all.length.should.eql(5);
+
+                theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
+                theme.results.error.byFiles['default.hbs'].length.should.eql(16);
+                theme.results.error.byFiles['post.hbs'].length.should.eql(54);
+                theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(5);
+                theme.results.error.byFiles['index.hbs'].length.should.eql(9);
+
+                done();
+            }).catch(done);
+        });
+
+        it('formats for CLI output', function () {
+            return checker(themePath('001-deprecations/v2/invalid_all'), options).then((theme) => {
+                theme = format(theme, {format: 'cli'});
+
+                theme.results.error[0].rule.should.equal('Replace \u001b[36m{{pageUrl}}\u001b[39m with \u001b[36m{{page_url}}\u001b[39m');
+
+                theme.results.error[0].details.should.startWith(`The helper \u001b[36m{{pageUrl}}\u001b[39m was replaced with \u001b[36m{{page_url}}\u001b[39m.\n`);
+                theme.results.error[0].details.should.endWith(`Find more information about the \u001b[36m{{page_url}}\u001b[39m helper here (https://ghost.org/docs/api/handlebars-themes/helpers/pagination/).`);
+            });
+        });
     });
 
-    it('assert sorting in empty theme', function (done) {
-        checker(themePath('is-empty')).then((theme) => {
-            theme = format(theme);
+    describe('canary:', function () {
+        const options = {checkVersion: 'canary'};
 
-            theme.results.error[0].fatal.should.eql(true);
-            theme.results.error[1].fatal.should.eql(true);
-            theme.results.error[4].fatal.should.eql(false);
-            theme.results.error[10].fatal.should.eql(false);
-            theme.results.error[11].fatal.should.eql(false);
-            theme.results.error[12].fatal.should.eql(false);
+        it('assert sorting in invalid theme', function (done) {
+            checker(themePath('005-compile/invalid'), options).then((theme) => {
+                theme = format(theme);
 
-            done();
-        }).catch(done);
-    });
+                theme.results.error.length.should.eql(27);
+                theme.results.error[0].fatal.should.eql(true);
+                // theme.results.error[1].fatal.should.eql(true);
+                // theme.results.error[2].fatal.should.eql(true);
+                theme.results.error[3].fatal.should.eql(false);
+                // theme.results.error[10].fatal.should.eql(false);
 
-    it('sort by files for invalid theme', function (done) {
-        checker(themePath('005-compile/invalid')).then((theme) => {
-            theme = format(theme, {sortByFiles: true});
+                done();
+            }).catch(done);
+        });
 
-            theme.results.hasFatalErrors.should.be.true();
+        it('assert sorting in empty theme', function (done) {
+            checker(themePath('is-empty'), options).then((theme) => {
+                theme = format(theme);
 
-            theme.results.recommendation.all.length.should.eql(1);
-            theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+                theme.results.error[0].fatal.should.eql(true);
+                theme.results.error[1].fatal.should.eql(true);
+                theme.results.error[4].fatal.should.eql(false);
+                theme.results.error[10].fatal.should.eql(false);
+                theme.results.error[11].fatal.should.eql(false);
+                theme.results.error[12].fatal.should.eql(false);
 
-            theme.results.warning.all.length.should.eql(3);
-            theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
+                done();
+            }).catch(done);
+        });
 
-            theme.results.error.all.length.should.eql(26);
+        it('sort by files for invalid theme', function (done) {
+            checker(themePath('005-compile/invalid'), options).then((theme) => {
+                theme = format(theme, {sortByFiles: true});
 
-            // 1 rule has file references
-            theme.results.error.byFiles['author.hbs'].length.should.eql(1);
-            theme.results.error.byFiles['page.hbs'].length.should.eql(1);
-            theme.results.error.byFiles['post.hbs'].length.should.eql(1);
-            theme.results.error.byFiles['index.hbs'].length.should.eql(1);
-            theme.results.error.byFiles['package.json'].length.should.eql(9);
+                theme.results.hasFatalErrors.should.be.true();
 
-            done();
-        }).catch(done);
-    });
+                theme.results.recommendation.all.length.should.eql(1);
+                theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
-    it('sort by files for invalid_all theme', function (done) {
-        checker(themePath('001-deprecations/v2/invalid_all')).then((theme) => {
-            theme = format(theme, {sortByFiles: true});
+                theme.results.warning.all.length.should.eql(4);
+                theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
 
-            theme.results.hasFatalErrors.should.be.true();
+                theme.results.error.all.length.should.eql(27);
 
-            theme.results.recommendation.all.length.should.eql(2);
-            theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
+                // 1 rule has file references
+                theme.results.error.byFiles['author.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['page.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['post.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['index.hbs'].length.should.eql(1);
+                theme.results.error.byFiles['package.json'].length.should.eql(10);
 
-            theme.results.error.all.length.should.eql(97);
-            theme.results.warning.all.length.should.eql(5);
+                done();
+            }).catch(done);
+        });
 
-            theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
-            theme.results.error.byFiles['default.hbs'].length.should.eql(16);
-            theme.results.error.byFiles['post.hbs'].length.should.eql(54);
-            theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(5);
-            theme.results.error.byFiles['index.hbs'].length.should.eql(9);
+        it('sort by files for invalid_all theme', function (done) {
+            checker(themePath('001-deprecations/canary/invalid_all'), options).then((theme) => {
+                theme = format(theme, {sortByFiles: true});
 
-            done();
-        }).catch(done);
-    });
+                theme.results.hasFatalErrors.should.be.true();
 
-    it('formats for CLI output', function () {
-        return checker(themePath('001-deprecations/v2/invalid_all')).then((theme) => {
-            theme = format(theme, {format: 'cli'});
+                theme.results.recommendation.all.length.should.eql(2);
+                theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
-            theme.results.error[0].rule.should.equal('Replace \u001b[36m{{pageUrl}}\u001b[39m with \u001b[36m{{page_url}}\u001b[39m');
+                theme.results.error.all.length.should.eql(99);
+                theme.results.warning.all.length.should.eql(6);
 
-            theme.results.error[0].details.should.startWith(`The helper \u001b[36m{{pageUrl}}\u001b[39m was replaced with \u001b[36m{{page_url}}\u001b[39m.\n`);
-            theme.results.error[0].details.should.endWith(`Find more information about the \u001b[36m{{page_url}}\u001b[39m helper here (https://ghost.org/docs/api/handlebars-themes/helpers/pagination/).`);
+                theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
+                theme.results.error.byFiles['default.hbs'].length.should.eql(17);
+                theme.results.error.byFiles['post.hbs'].length.should.eql(54);
+                theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(5);
+                theme.results.error.byFiles['index.hbs'].length.should.eql(9);
+
+                done();
+            }).catch(done);
+        });
+
+        it('formats for CLI output', function () {
+            return checker(themePath('001-deprecations/canary/invalid_all'), options).then((theme) => {
+                theme = format(theme, {format: 'cli'});
+
+                theme.results.error[0].rule.should.equal('Replace \u001b[36m{{pageUrl}}\u001b[39m with \u001b[36m{{page_url}}\u001b[39m');
+
+                theme.results.error[0].details.should.startWith(`The helper \u001b[36m{{pageUrl}}\u001b[39m was replaced with \u001b[36m{{page_url}}\u001b[39m.\n`);
+                theme.results.error[0].details.should.endWith(`Find more information about the \u001b[36m{{page_url}}\u001b[39m helper here (https://ghost.org/docs/api/handlebars-themes/helpers/pagination/).`);
+            });
         });
     });
 });


### PR DESCRIPTION
Changed:
- [x] When the version passed into checker is 'latest' it should default to v3
- [x] Extended 'Format' suite with version specific formatting tests