### PR TITLE
🐛 Removed file sorting in zip reading

### DIFF
--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
 
 const resolveBaseDir = (zipPath) => {
     return new Promise((resolve) => {
-        glob('**/index.hbs', {cwd: zipPath}, function (err, matches) {
+        glob('**/index.hbs', {cwd: zipPath, nosort: true}, function (err, matches) {
             var matchedPath;
 
             if (!err && !_.isEmpty(matches)) {


### PR DESCRIPTION
no issue

Disables the alphabetical sorting, which makes sure the paths are sorted from shortest to highest number of sub-folders.