### PR TITLE
💄 Added new check for {{@labs.members}} helper use

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -40,7 +40,7 @@ let rules = {
         level: 'warning',
         rule: 'The <code>{{@labs.members}}</code> helper should not be used.',
         details: oneLineTrim`Please remove <code>{{@labs.members}}</code> from the theme.<br>
-        The <code>{{@labs.members}}</code> helper will default to "true" value in Ghost v4 and will be removed from Ghost v5, thus resolving to "false" value.
+        The <code>{{@labs.members}}</code> helper will always return <code>true</code> in Ghost v4 and will be removed from Ghost v5, at which point it will return <code>null</code> and evaluate to <code>false</code>.
         Find more information about the <code>@labs.members</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,
         regex: /@labs\.members/g,
         helper: '{{@labs.members}}'

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -41,7 +41,7 @@ let rules = {
         rule: 'The <code>{{@labs.members}}</code> helper should not be used.',
         details: oneLineTrim`Please remove <code>{{@labs.members}}</code> from the theme.<br>
         The <code>{{@labs.members}}</code> helper will always return <code>true</code> in Ghost v4 and will be removed from Ghost v5, at which point it will return <code>null</code> and evaluate to <code>false</code>.
-        Find more information about the <code>@labs.members</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,
+        Find more information about the <code>@labs</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,
         regex: /@labs\.members/g,
         helper: '{{@labs.members}}'
     }

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -38,7 +38,7 @@ let rules = {
     },
     'GS001-DEPR-LABS-MEMBERS': {
         level: 'warning',
-        rule: 'The <code>{{@labs.members}}</code> helper should not be used and removed from the theme.',
+        rule: 'The <code>{{@labs.members}}</code> helper should not be used.',
         details: oneLineTrim`Please remove <code>{{@labs.members}}</code> from the theme.<br>
         The <code>{{@labs.members}}</code> helper will default to "true" value in Ghost v4 and will be removed from Ghost v5, thus resolving to "false" value.
         Find more information about the <code>@labs.members</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -35,6 +35,15 @@ let rules = {
         details: oneLineTrim`Please change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v4"}}</code>.<br>
         If <code>"ghost-api"</code> property is left at "v2", it will stop working with next major version upgrade and default to v5.<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.`
+    },
+    'GS001-DEPR-LABS-MEMBERS': {
+        level: 'warning',
+        rule: 'The <code>{{@labs.members}}</code> helper should not be used and removed from the theme.',
+        details: oneLineTrim`Please remove <code>{{@labs.members}}</code> from the theme.<br>
+        The <code>{{@labs.members}}</code> helper will default to "true" value in Ghost v4 and will be removed from Ghost v5, thus resolving to "false" value.
+        Find more information about the <code>@labs.members</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,
+        regex: /@labs\.members/g,
+        helper: '{{@labs.members}}'
     }
 };
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -1611,7 +1611,8 @@ describe('001 Deprecations', function () {
                     'GS001-DEPR-LANG',
                     'GS001-DEPR-PAID',
                     'GS001-DEPR-USER-GET',
-                    'GS001-DEPR-EACH'
+                    'GS001-DEPR-EACH',
+                    'GS001-DEPR-LABS-MEMBERS'
                 );
 
                 // pageUrl
@@ -1895,6 +1896,10 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-EACH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-EACH'].failures.length.should.eql(1);
 
+                // {{@labs.members}} helper usage warning
+                output.results.fail['GS001-DEPR-LABS-MEMBERS'].should.be.a.ValidFailObject();
+                output.results.fail['GS001-DEPR-LABS-MEMBERS'].failures.length.should.eql(1);
+
                 // there are some single author rules which are not invalid for this theme.
                 output.results.pass.length.should.eql(17);
 
@@ -2140,7 +2145,7 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-EACH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-EACH'].failures.length.should.eql(1);
 
-                output.results.pass.should.be.an.Array().with.lengthOf(46);
+                output.results.pass.should.be.an.Array().with.lengthOf(47);
 
                 done();
             }).catch(done);
@@ -2151,7 +2156,7 @@ describe('001 Deprecations', function () {
                 output.should.be.a.ValidThemeObject();
 
                 output.results.fail.should.be.an.Object().which.is.empty();
-                output.results.pass.should.be.an.Array().with.lengthOf(92);
+                output.results.pass.should.be.an.Array().with.lengthOf(93);
 
                 done();
             }).catch(done);
@@ -2205,7 +2210,7 @@ describe('001 Deprecations', function () {
                 output.results.fail['GS001-DEPR-AUTH'].should.be.a.ValidFailObject();
                 output.results.fail['GS001-DEPR-AUTH'].failures.length.should.eql(1);
 
-                output.results.pass.should.be.an.Array().with.lengthOf(58);
+                output.results.pass.should.be.an.Array().with.lengthOf(59);
 
                 done();
             }).catch(done);

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -161,7 +161,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(99);
+            theme.results.pass.should.be.an.Array().with.lengthOf(100);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(
@@ -196,7 +196,7 @@ describe('Checker', function () {
                 {file: 'README.md', ext: '.md'}
             ]);
 
-            theme.results.pass.should.be.an.Array().with.lengthOf(99);
+            theme.results.pass.should.be.an.Array().with.lengthOf(100);
             theme.results.pass.should.containEql('GS005-TPL-ERR', 'GS030-ASSET-REQ', 'GS030-ASSET-SYM');
 
             theme.results.fail.should.be.an.Object().with.keys(

--- a/test/fixtures/themes/001-deprecations/canary/invalid_all/default.hbs
+++ b/test/fixtures/themes/001-deprecations/canary/invalid_all/default.hbs
@@ -15,6 +15,10 @@
 
     {{cover}}
 
+    {{#if @labs.members}}
+        <h1>Hi Member!</h1>
+    {{/if}}
+
     {{#get "posts" include="tags, author" fields="author" filter="author:{{author.slug}}+id:-{{id}}"}}
         {{#foreach posts}}
             {{author}}

--- a/test/fixtures/themes/001-deprecations/v3/invalid_all/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v3/invalid_all/default.hbs
@@ -15,6 +15,10 @@
 
     {{cover}}
 
+   {{#if @labs.members}}
+        <h1>Hi Member!</h1>
+    {{/if}}
+
     {{#get "posts" include="tags, author" fields="author" filter="author:{{author.slug}}+id:-{{id}}"}}
         {{#foreach posts}}
             {{author}}

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -256,7 +256,7 @@ describe('Format', function () {
                 theme.results.recommendation.byFiles['package.json'].length.should.eql(1);
 
                 theme.results.error.all.length.should.eql(99);
-                theme.results.warning.all.length.should.eql(7);
+                theme.results.warning.all.length.should.eql(8);
 
                 theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
                 theme.results.error.byFiles['default.hbs'].length.should.eql(17);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/492

:warning: WIP: needs:
- [x] some tests
- [x] a copy check!

Ghost 4.0 sets labs.members flat to always be "true" by default and will remove the property completely (resolving it ot "false") starting with next version - Ghost 5.0