### PR TITLE
Fix spacing mistakes

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -40,7 +40,7 @@ let rules = {
         level: 'warning',
         rule: 'The <code>{{@labs.members}}</code> helper should not be used.',
         details: oneLineTrim`Please remove <code>{{@labs.members}}</code> from the theme.<br>
-        The <code>{{@labs.members}}</code> helper will always return <code>true</code> in Ghost v4 and will be removed from Ghost v5, at which point it will return <code>null</code> and evaluate to <code>false</code>.
+        The <code>{{@labs.members}}</code> helper will always return <code>true</code> in Ghost v4 and will be removed from Ghost v5, at which point it will return <code>null</code> and evaluate to <code>false</code>.<br>
         Find more information about the <code>@labs</code> property <a href="${docsBaseUrl}helpers/labs/" target=_blank>here</a>.`,
         regex: /@labs\.members/g,
         helper: '{{@labs.members}}'
@@ -48,7 +48,7 @@ let rules = {
     'GS080-FEACH-POSTS': {
         level: 'warning',
         rule: 'The default visibility for posts in <code>{{#foreach}}</code> block helper has changed in v4.',
-        details: oneLineTrim`The default visibility for posts in <code>{{#foreach}}</code> block helper has changed from <code>public</code> to <code>all</code> in Ghost v4.
+        details: oneLineTrim`The default visibility for posts in <code>{{#foreach}}</code> block helper has changed from <code>public</code> to <code>all</code> in Ghost v4.<br>
         Find more information about the <code>{{foreach}}</code> helper <a href="${docsBaseUrl}helpers/foreach/" target=_blank>here</a>.`,
         regex: /{{\s*?#foreach\s*?\w*?\s*?}}/g,
         helper: '{{#foreach}}',
@@ -57,7 +57,7 @@ let rules = {
     'GS080-CARD-LAST4': {
         level: 'warning',
         rule: 'The <code>default_payment_card_last4</code> field now coalesces to <code>****</code> in Ghost 4.x instead of null.',
-        details: oneLineTrim`The <code>default_payment_card_last4</code> field no longer outputs a falsy(null) value in case of missing card details starting from Ghost 4.x and instead coalesces to <code>****</code>
+        details: oneLineTrim`The <code>default_payment_card_last4</code> field no longer outputs a falsy(null) value in case of missing card details starting from Ghost 4.x and instead coalesces to <code>****</code><br>
         Find more information about the <code>default_payment_card_last4</code> attribute <a href="${docsBaseUrl}members/#subscription-attributes" target=_blank>here</a>.`,
         regex: /default_payment_card_last4/g,
         helper: '{{default_payment_card_last4}}',
@@ -66,8 +66,8 @@ let rules = {
     'GS080-FEACH-PV': {
         level: 'recommendation',
         rule: 'The use of <code>visibility="all"</code> is no longer required for posts in <code>{{#foreach}}</code> helper.',
-        details: oneLineTrim`The default visibility in <code>{{#foreach}}</code> helper for posts has changed in v4 from "public" to "all" and is no longer required when looping over posts.
-        Check out the documentation for <code>{{#foreach}}</code> <a href="${docsBaseUrl}helpers/foreach/" target=_blank>here</a>.<br>.`,
+        details: oneLineTrim`The default visibility in <code>{{#foreach}}</code> helper for posts has changed in v4 from "public" to "all" and is no longer required when looping over posts.<br>
+        Check out the documentation for <code>{{#foreach}}</code> <a href="${docsBaseUrl}helpers/foreach/" target=_blank>here</a>.`,
         regex: /{{\s*?#foreach\b[\w\s='"]*?visibility=("|')all("|')[\w\s='"]*?}}/g,
         helper: '{{#foreach}}',
         validInAPI: ['v3']
@@ -75,7 +75,7 @@ let rules = {
     'GS001-DEPR-CURR-SYM': {
         level: 'warning',
         rule: 'Replace <code>{{[#].currency_symbol}}</code> with <code>{{price currency=currency}}</code>.',
-        details: oneLineTrim`The hardcoded <code>currency_symbol</code> attribute was removed in favour of passing the currency to updated <code>{{price}}</code> helper.
+        details: oneLineTrim`The hardcoded <code>currency_symbol</code> attribute was removed in favour of passing the currency to updated <code>{{price}}</code> helper.<br>
         Find more information about the updated <code>{{price}}</code> helper <a href="${docsBaseUrl}members/#the-price-helper" target=_blank>here</a>.`,
         helper: '{{[#].currency_symbol}}',
         regex: /currency_symbol/g
@@ -84,7 +84,7 @@ let rules = {
         level: 'warning',
         rule: 'The <code>{{@site.lang}}</code> helper should be replaced with <code>{{@site.locale}}</code>',
         details: oneLineTrim`Please replace <code>{{@site.lang}}</code> helper with <code>{{@site.locale}}</code>.<br>
-        The <code>{{@site.lang}}</code> helper will be removed in next version of Ghost and should not be used.
+        The <code>{{@site.lang}}</code> helper will be removed in next version of Ghost and should not be used.<br>
         Find more information about the <code>@site</code> property <a href="${docsBaseUrl}helpers/site/" target=_blank>here</a>.`,
         regex: /@site\.lang/g,
         helper: '{{@site.lang}}'

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -99,8 +99,7 @@ rules = {
         details: oneLineTrim`The <code>{{image}}</code> helper was replaced with the <code>{{img_url}}</code> helper.<br>
         Depending on the context of the <code>{{img_url}}</code> helper you would need to use e. g. <br><br><code>{{#post}}<br>&nbsp;&nbsp;&nbsp;&nbsp;{{img_url feature_image}}<br>{{/post}}</code><br><br>to render the feature image of the blog post.<br>
         <br><b>If you are using <code>{{if image}}</code></b>, then you have to replace it with e.g. <code>{{if feature_image}}.</code>
-        <br><br>Find more information about the <code>{{img_url}}</code> helper <a href="${docsBaseUrl}helpers/img_url/" target=_blank>here</a> and
-        read more about Ghost's usage of contexts <a href="${docsBaseUrl}context/" target=_blank>here</a>.`,
+        <br><br>Find more information about the <code>{{img_url}}</code> helper <a href="${docsBaseUrl}helpers/img_url/" target=_blank>here</a> and read more about Ghost's usage of contexts <a href="${docsBaseUrl}context/" target=_blank>here</a>.`,
         regex: /{{\s*?image\b[\w\s='"]*?}}/g,
         helper: '{{image}}'
     },
@@ -365,22 +364,18 @@ rules = {
         level: 'error',
         rule: 'Replace <code>{{id}}</code> with <code>{{comment_id}}</code> in Disqus embeds.',
         fatal: true,
-        details: oneLineTrim`The output of <code>{{id}}</code> has changed in v1.0.0 from an incremental ID to an ObjectID.
-        This results in Disqus comments not loading in Ghost v1.0.0 posts which were imported from earlier versions.
-        To resolve this, we've added a <code>{{comment_id}}</code> helper that will output the old ID
-        for posts that have been imported from earlier versions, and ID for new posts.
-        The Disqus embed must be updated from <code>this.page.identifier = 'ghost-{{id}}';</code> to
-        <code>this.page.identifier = 'ghost-{{comment_id}}';</code> to ensure Disqus continues to work.`,
+        details: oneLineTrim`The output of <code>{{id}}</code> has changed in v1.0.0 from an incremental ID to an ObjectID.<br>
+        This results in Disqus comments not loading in Ghost v1.0.0 posts which were imported from earlier versions.<br>
+        To resolve this, we've added a <code>{{comment_id}}</code> helper that will output the old ID for posts that have been imported from earlier versions, and ID for new posts.<br>
+        The Disqus embed must be updated from <code>this.page.identifier = 'ghost-{{id}}';</code> to <code>this.page.identifier = 'ghost-{{comment_id}}';</code> to ensure Disqus continues to work.`,
         regex: /(page\.|disqus_)identifier\s?=\s?['"].*?({{\s*?id\s*?}}).*?['"];?/g
     },
     'GS002-ID-HELPER': {
         level: 'recommendation',
         rule: 'The output of <code>{{id}}</code> changed in Ghost v1.0.0, you may need to use <code>{{comment_id}}</code> instead.',
-        details: oneLineTrim`The output of <code>{{id}}</code> has changed in v1.0.0 from an incremental ID to an ObjectID.
-        In v1.0.0 we added a <code>{{comment_id}}</code> helper that will output the old ID
-        for posts that have been imported from earlier versions, and ID for new posts.
-        If you need the old ID to be output on imported posts, then you will need to use
-        <code>{{comment_id}}</code> rather than <code>{{id}}</code>.`,
+        details: oneLineTrim`The output of <code>{{id}}</code> has changed in v1.0.0 from an incremental ID to an ObjectID.<br>
+        In v1.0.0 we added a <code>{{comment_id}}</code> helper that will output the old ID for posts that have been imported from earlier versions, and ID for new posts.<br>
+        If you need the old ID to be output on imported posts, then you will need to use <code>{{comment_id}}</code> rather than <code>{{id}}</code>.`,
         regex: /({{\s*?id\s*?}})/g
     },
     'GS005-TPL-ERR': {
@@ -401,7 +396,7 @@ rules = {
         rule: '<code>package.json</code> file can be parsed',
         details: oneLineTrim`Your <code>package.json</code> file couldn't be parsed. This is mostly caused by a missing or unnecessary <code>','</code> or the wrong usage of <code>'""'</code>.<br>
         Check the <a href="${docsBaseUrl}packagejson/" target=_blank><code>package.json</code> documentation</a> for further information.<br>
-        A good reference for your <code>package.json</code> file is always the latest version of  <a href="https://github.com/TryGhost/Casper/blob/master/package.json" target=_blank>Casper</a>.`
+        A good reference for your <code>package.json</code> file is always the latest version of <a href="https://github.com/TryGhost/Casper/blob/master/package.json" target=_blank>Casper</a>.`
     },
     'GS010-PJ-NAME-LC': {
         level: 'error',

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -57,8 +57,7 @@ let rules = {
     'GS001-DEPR-AUTHBL': {
         level: 'error',
         rule: 'The <code>{{#author}}</code> block helper should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>',
-        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is deprecated and
-        should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
+        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is deprecated and should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}helpers/authors/" target=_blank>here</a>.`,
         regex: /{{\s*?#author\s*?}}/g,
         notValidIn: 'author.hbs',
@@ -384,7 +383,7 @@ let rules = {
         level: 'error',
         rule: 'The <code>{{@blog}}</code> helper should be replaced with <code>{{@site}}</code>',
         details: oneLineTrim`With the introduction of the Content API <code>{{@blog}}</code> became deprecated in favour of <code>{{@site}}</code>.<br>
-        The <code>{{@blog}}</code> helper will be removed in next version of Ghost and should not be used.
+        The <code>{{@blog}}</code> helper will be removed in next version of Ghost and should not be used.<br>
         Find more information about the <code>@site</code> property <a href="${docsBaseUrl}helpers/site/" target=_blank>here</a>.`,
         regex: /{{\s*?@blog\.[a-zA-Z0-9_]+\s*?}}/g,
         helper: '{{@blog}}'
@@ -393,7 +392,7 @@ let rules = {
         level: 'error',
         rule: '<code>{{@blog.permalinks}}</code> was removed',
         details: oneLineTrim`With the introduction of Dynamic Routing, you can define multiple permalinks.<br>
-        The <code>{{@blog.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.
+        The <code>{{@blog.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.<br>
         Find more information about Ghost data helpers <a href="${docsBaseUrl}/helpers/data/" target=_blank>here</a>.`,
         regex: /{{\s*?@blog\.permalinks\s*?}}/g,
         helper: '{{@blog.permalinks}}'
@@ -402,7 +401,7 @@ let rules = {
         level: 'error',
         rule: '<code>{{@site.permalinks}}</code> was removed',
         details: oneLineTrim`With the introduction of Dynamic Routing, you can define multiple permalinks.<br>
-        The <code>{{@site.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.
+        The <code>{{@site.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.<br>
         Find more information about the <code>@site</code> property <a href="${docsBaseUrl}helpers/site/" target=_blank>here</a>.`,
         regex: /{{\s*?@site\.permalinks\s*?}}/g,
         helper: '{{@site.permalinks}}'
@@ -411,7 +410,7 @@ let rules = {
         level: 'error',
         rule: 'Replace <code>{{@site.ghost_head}}</code> with <code>{{ghost_head}}</code>',
         details: oneLineTrim`The usage of <code>{{@site.ghost_head}}</code> is deprecated and should be replaced with <code>{{ghost_head}}</code>.<br>
-        The <code>{{@site.ghost_head}}</code> property will therefore no longer be used and should be removed from the theme.
+        The <code>{{@site.ghost_head}}</code> property will therefore no longer be used and should be removed from the theme.<br>
         Find more information about the <code>{{ghost_head}}</code> property <a href="${docsBaseUrl}helpers/ghost_head_foot/" target=_blank>here</a>.`,
         regex: /{{\s*?@site\.ghost_head\s*?}}/g,
         helper: '{{@site.ghost_head}}'
@@ -420,7 +419,7 @@ let rules = {
         level: 'error',
         rule: 'Replace <code>{{@site.ghost_foot}}</code> with <code>{{ghost_foot}}</code>',
         details: oneLineTrim`The usage of <code>{{@site.ghost_foot}}</code> is deprecated and should be replaced with <code>{{ghost_foot}}</code>.<br>
-        The <code>{{@site.ghost_foot}}</code> property will therefore no longer be used and should be removed from the theme.
+        The <code>{{@site.ghost_foot}}</code> property will therefore no longer be used and should be removed from the theme.<br>
         Find more information about the <code>{{ghost_foot}}</code> property <a href="${docsBaseUrl}helpers/ghost_head_foot/" target=_blank>here</a>.`,
         regex: /{{\s*?@site\.ghost_foot\s*?}}/g,
         helper: '{{@site.ghost_foot}}'
@@ -429,7 +428,7 @@ let rules = {
         level: 'error',
         rule: 'The <code>{{lang}}</code> helper should be replaced with <code>{{@site.lang}}</code>',
         details: oneLineTrim`The <code>{{lang}}</code> helper is a duplicate of <code>{{@site.lang}}</code>. Using <code>{{@site.lang}}</code> is preferred.<br>
-        The <code>{{lang}}</code> helper will be removed in next version of Ghost and should not be used.
+        The <code>{{lang}}</code> helper will be removed in next version of Ghost and should not be used.<br>
         Find more information about the <code>@site.lang</code> property <a href="${docsBaseUrl}helpers/site/" target=_blank>here</a>.`,
         regex: /{{\s*?lang\s*?}}/g,
         helper: '{{lang}}'
@@ -437,8 +436,8 @@ let rules = {
     'GS001-DEPR-CSS-KGMD': {
         level: 'warning',
         rule: `<code>.kg-card-markdown</code> doesn't exist in current version of Ghost, ensure your theme works without it`,
-        details: oneLineTrim`The <code>.kg-card-markdown</code> CSS class is deprecated and will no longer be used in Ghost.
-        It's recommended to add your own wrapper around the <code>{{content}}</code> helper and target that instead if needed.
+        details: oneLineTrim`The <code>.kg-card-markdown</code> CSS class is deprecated and will no longer be used in Ghost.<br>
+        It's recommended to add your own wrapper around the <code>{{content}}</code> helper and target that instead if needed.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/" target=_blank>here</a>.`,
         regex: /\.kg-card-markdown/g,
         className: '.kg-card-markdown',
@@ -447,7 +446,7 @@ let rules = {
     'GS050-CSS-KGWW': {
         level: 'error',
         rule: 'The <code>.kg-width-wide</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-width-wide</code> CSS class is required otherwise wide images will appear unstyled.
+        details: oneLineTrim`The <code>.kg-width-wide</code> CSS class is required otherwise wide images will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#image-size-implementations" target=_blank>here</a>.`,
         regex: /\.kg-width-wide/g,
         className: '.kg-width-wide',
@@ -456,7 +455,7 @@ let rules = {
     'GS050-CSS-KGWF': {
         level: 'error',
         rule: 'The <code>.kg-width-full</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-width-full</code> CSS class is required otherwise full width images will appear unstyled.
+        details: oneLineTrim`The <code>.kg-width-full</code> CSS class is required otherwise full width images will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#image-size-implementations" target=_blank>here</a>.`,
         regex: /\.kg-width-full/g,
         className: '.kg-width-full',
@@ -465,7 +464,7 @@ let rules = {
     'GS050-CSS-KGGC': {
         level: 'error',
         rule: 'The <code>.kg-gallery-container</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-gallery-container</code> CSS class is required otherwise galleries will appear unstyled.
+        details: oneLineTrim`The <code>.kg-gallery-container</code> CSS class is required otherwise galleries will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#gallery-card" target=_blank>here</a>.`,
         regex: /\.kg-gallery-container/g,
         className: '.kg-gallery-container',
@@ -474,7 +473,7 @@ let rules = {
     'GS050-CSS-KGGR': {
         level: 'error',
         rule: 'The <code>.kg-gallery-row</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-gallery-row</code> CSS class is required otherwise gallery rows will appear unstyled.
+        details: oneLineTrim`The <code>.kg-gallery-row</code> CSS class is required otherwise gallery rows will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#gallery-card" target=_blank>here</a>.`,
         regex: /\.kg-gallery-row/g,
         className: '.kg-gallery-row',
@@ -483,7 +482,7 @@ let rules = {
     'GS050-CSS-KGGI': {
         level: 'error',
         rule: 'The <code>.kg-gallery-image</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-gallery-image</code> CSS class is required otherwise gallery images will appear unstyled.
+        details: oneLineTrim`The <code>.kg-gallery-image</code> CSS class is required otherwise gallery images will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#gallery-card" target=_blank>here</a>.`,
         regex: /\.kg-gallery-image/g,
         className: '.kg-gallery-image',
@@ -492,7 +491,7 @@ let rules = {
     'GS050-CSS-KGBM': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-card</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-card/g,
         className: '.kg-bookmark-card',
@@ -501,7 +500,7 @@ let rules = {
     'GS050-CSS-KGBMCO': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-container</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-card</code> CSS class is required otherwise the bookmark card will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-container/g,
         className: '.kg-bookmark-container',
@@ -510,7 +509,7 @@ let rules = {
     'GS050-CSS-KGBMCON': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-content</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-content</code> CSS class is required otherwise the bookmark card main content will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-content</code> CSS class is required otherwise the bookmark card main content will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-content/g,
         className: '.kg-bookmark-content',
@@ -519,7 +518,7 @@ let rules = {
     'GS050-CSS-KGBMTI': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-title</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-title</code> CSS class is required otherwise the bookmark card title will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-title</code> CSS class is required otherwise the bookmark card title will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-title/g,
         className: '.kg-bookmark-title',
@@ -528,7 +527,7 @@ let rules = {
     'GS050-CSS-KGBMDE': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-description</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-description</code> CSS class is required otherwise the bookmark card description will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-description</code> CSS class is required otherwise the bookmark card description will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-description/g,
         className: '.kg-bookmark-description',
@@ -537,7 +536,7 @@ let rules = {
     'GS050-CSS-KGBMME': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-metadata</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-metadata</code> CSS class is required otherwise the bookmark card meta details will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-metadata</code> CSS class is required otherwise the bookmark card meta details will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-metadata/g,
         className: '.kg-bookmark-metadata',
@@ -546,7 +545,7 @@ let rules = {
     'GS050-CSS-KGBMIC': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-icon</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-icon</code> CSS class is required otherwise the bookmark card author icon will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-icon</code> CSS class is required otherwise the bookmark card author icon will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-icon/g,
         className: '.kg-bookmark-icon',
@@ -555,7 +554,7 @@ let rules = {
     'GS050-CSS-KGBMAU': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-author</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-author</code> CSS class is required otherwise the bookmark card author name will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-author</code> CSS class is required otherwise the bookmark card author name will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-author/g,
         className: '.kg-bookmark-author',
@@ -564,7 +563,7 @@ let rules = {
     'GS050-CSS-KGBMPU': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-publisher</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-publisher</code> CSS class is required otherwise the bookmark card publisher name will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-publisher</code> CSS class is required otherwise the bookmark card publisher name will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-publisher/g,
         className: '.kg-bookmark-publisher',
@@ -573,7 +572,7 @@ let rules = {
     'GS050-CSS-KGBMTH': {
         level: 'error',
         rule: 'The <code>.kg-bookmark-thumbnail</code> CSS class is required to appear styled in your theme',
-        details: oneLineTrim`The <code>.kg-bookmark-thumbnail</code> CSS class is required otherwise the bookmark card thumbnail image will appear unstyled.
+        details: oneLineTrim`The <code>.kg-bookmark-thumbnail</code> CSS class is required otherwise the bookmark card thumbnail image will appear unstyled.<br>
         Find out more about required theme changes for the Koenig editor <a href="${docsBaseUrl}editor/#bookmark-card" target=_blank>here</a>.`,
         regex: /\.kg-bookmark-thumbnail/g,
         className: '.kg-bookmark-thumbnail',

--- a/lib/specs/v3.js
+++ b/lib/specs/v3.js
@@ -34,7 +34,7 @@ let rules = {
         level: 'error',
         rule: 'Replace <code>{{error.code}}</code> with <code>{{error.statusCode}}</code>',
         details: oneLineTrim`The usage of <code>{{error.code}}</code> is deprecated and should be replaced with <code>{{error.statusCode}}</code>.<br>
-        When in <code>error</code> context, e. g. in the <code>error.hbs</code> template, replace <code>{{code}}</code> with <code>{{statusCode}}</code>.<br>
+        When in <code>error</code> context, e.g. in the <code>error.hbs</code> template, replace <code>{{code}}</code> with <code>{{statusCode}}</code>.<br>
         Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}structure/#errorhbs" target=_blank>here</a>.`,
         regex: /{{\s*?(?:error\.)?(code)\s*?}}/g,
         helper: '{{error.code}}'


### PR DESCRIPTION
I recently passed my theme through GScan and noticed that there were a few spacing errors as well as an extra full stop.

![GScan](https://user-images.githubusercontent.com/27488257/114805516-81c2d380-9de6-11eb-8f65-27fb62ee726f.png)

Looking through the relevant file and other related files I noticed a few more typos in the same vein. Here's a bit of an attempt to rectify those.