### PR TITLE
Only load the `isEmail` function from the validator library

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const semver = require('semver');
-const validator = require('validator');
+const isEmail = require('validator/lib/isEmail');
 const _private = {};
 const packageJSONFileName = 'package.json';
 const versions = require('../utils').versions;
@@ -92,7 +92,7 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
         markFailed('versionIsSemverCompliant');
     }
 
-    if (packageJSON.author && packageJSON.author.email && !validator.isEmail(packageJSON.author.email)) {
+    if (packageJSON.author && packageJSON.author.email && !isEmail(packageJSON.author.email)) {
         markFailed('authorEmailIsValid');
     }
 


### PR DESCRIPTION
issue https://github.com/TryGhost/Team/issues/706

This reduces parsing time as node doesn't need to parse the whole validator.js library.

## Benchmark before the change

```
hyperfine --warmup 3  --min-runs 30 '/Users/thibautpatel/.nvm/versions/node/v14.17.0/bin/node bin/cli.js ../Casper'
Benchmark #1: /Users/thibautpatel/.nvm/versions/node/v14.17.0/bin/node bin/cli.js ../Casper
  Time (mean ± σ):     464.4 ms ±   8.3 ms    [User: 491.5 ms, System: 79.2 ms]
  Range (min … max):   453.6 ms … 495.5 ms    30 runs
```

## Benchmark after the change

```
Benchmark #1: /Users/thibautpatel/.nvm/versions/node/v14.17.0/bin/node bin/cli.js ../Casper
  Time (mean ± σ):     443.8 ms ±   6.0 ms    [User: 478.0 ms, System: 74.3 ms]
  Range (min … max):   433.5 ms … 461.6 ms    30 runs
```

So this is approximately 20ms shaved from an unzipped gscan check.