### PR TITLE
Exposed custom theme settings read from package.json

### DIFF
--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -75,9 +75,11 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
 /**
  *
  * @param {Theme} theme
+ * @param {Object} options
+ * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
  * @returns {Promise<Theme>}
  */
-const readFiles = function readFiles(theme) {
+const readFiles = function readFiles(theme, options = {}) {
     const themeFilesContent = _.filter(theme.files, function (themeFile) {
         if (themeFile && themeFile.ext) {
             return themeFile.ext.match(/\.hbs|\.css|\.js/ig) || themeFile.file.match(/package.json/i);
@@ -95,6 +97,20 @@ const readFiles = function readFiles(theme) {
     return Promise.map(themeFilesContent, function (themeFile) {
         return fs.readFile(path.join(theme.path, themeFile.file), 'utf8').then(function (content) {
             themeFile.content = content;
+
+            if (options.labs && options.labs.customThemeSettings) {
+                if (!theme.customSettings) {
+                    theme.customSettings = {};
+                }
+
+                const packageJsonMatch = themeFile.file.match(/^package\.json/);
+                if (packageJsonMatch) {
+                    const packageJson = JSON.parse(themeFile.content);
+                    if (packageJson.config.custom) {
+                        theme.customSettings = packageJson.config.custom;
+                    }
+                }
+            }
 
             const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
             if (partialMatch) {
@@ -214,9 +230,11 @@ const extractTemplates = function extractTemplates(allFiles) {
 /**
  *
  * @param {string} themePath - path to the validated theme
+ * @param {Object} options
+ * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
  * @returns {Promise<Theme>}
  */
-module.exports = function readTheme(themePath) {
+module.exports = function readTheme(themePath, options = {}) {
     return readThemeStructure(themePath)
         .then(function (themeFiles) {
             var allTemplates = extractTemplates(themeFiles);
@@ -234,7 +252,7 @@ module.exports = function readTheme(themePath) {
                     pass: [],
                     fail: {}
                 }
-            });
+            }, options);
         });
 };
 
@@ -250,4 +268,5 @@ module.exports = function readTheme(themePath) {
  * @param {Object} results
  * @param {Object[]} results.pass
  * @param {Object} results.fail
+ * @param {Object=} customSettings
  */

--- a/test/fixtures/themes/theme-with-custom-settings-packagejson/package.json
+++ b/test/fixtures/themes/theme-with-custom-settings-packagejson/package.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "custom": {
+      "test_select": {
+        "type": "select",
+        "options": ["one", "two"],
+        "default": "two"
+      }
+    }
+  }
+}

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -48,6 +48,8 @@ describe('Read theme', function () {
             fileNames.should.containEql({file: 'post.hbs', ext: '.hbs'});
             fileNames.should.containEql({file: 'logo.new.hbs', ext: '.hbs'});
 
+            theme.should.not.have.key('customSettings');
+
             done();
         }).catch(done);
     });
@@ -167,5 +169,25 @@ describe('Read theme', function () {
                 result.partials.should.eql(['mypartial', 'subfolder\\test']);
                 done();
             }).catch(done);
+    });
+
+    it('can extract custom settings from package.json', function (done) {
+        const options = {labs: {customThemeSettings: true}};
+
+        readTheme(themePath('theme-with-custom-settings-packagejson'), options).then((theme) => {
+            theme.should.be.a.ValidThemeObject();
+
+            should.exist(theme.customSettings);
+
+            theme.customSettings.should.deepEqual({
+                test_select: {
+                    type: 'select',
+                    options: ['one', 'two'],
+                    default: 'two'
+                }
+            });
+
+            done();
+        }).catch(done);
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1070

- pass `options` from `check()` and `checkZip()` through to `readTheme()` so the labs flags are available where needed
- when `labs.customThemeSettings === true`, inside `readTheme()` read `package.json` and add a `customSettings` property to the theme object returned by `check()` and `checkZip()`
