### PR TITLE
Added match helper to allowed list when labs feature is enabled

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -16,6 +16,7 @@ const checks = requireDir('./checks');
  * @param {Object} options
  * @param {string} [options.checkVersion] version to check the theme against
  * @param {string} [options.themeName] name of the checked theme
+ * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
  * @returns {Promise<Object>}
  */
 const checker = function checkAll(themePath, options = {}) {
@@ -26,7 +27,14 @@ const checker = function checkAll(themePath, options = {}) {
         version = 'canary';
     }
 
-    return readTheme(themePath)
+    if (options.labs && options.labs.matchHelper) {
+        const spec = require('./specs').get([version]);
+        if (!spec.knownHelpers.includes('match')) {
+            spec.knownHelpers.push('match');
+        }
+    }
+
+    return readTheme(themePath, options)
         .then(function (theme) {
             // set the major version to check
             theme.checkedVersion = versions[version].major;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const {errors} = require('ghost-ignition');
  * @param {Object} options
  * @param {boolean} options.keepExtractedDir flag controling if the directory with extracted zip should stay after the check is complete
  * @param {string} options.checkVersion version to check the theme against
+ * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
  * @returns {Promise<any>}
  */
 const checkZip = async function checkZip(path, options) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1070

- added `allowMatchHelper` option to `check()` and `checkZip()` methods
- when option is true, manually push `match` to the allowed helper list
