### PR TITLE
🔥 Added support for Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '12.10.0', '14.13.0' ]
+        node: [ '12.22.1', '14.17.0', '16.13.0' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:TryGhost/gscan.git"
   },
   "engines": {
-    "node": "^12.10.0 || ^14.13.0"
+    "node": "^12.22.1 || ^14.17.0 || ^16.13.0"
   },
   "bugs": {
     "url": "https://github.com/TryGhost/gscan/issues"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/71

- Node 16 is now LTS so we're picking up support for it
- this commit adds it to CI and updates our supported range
- also fixes Node 12 and Node 14 versions - we bumped these
  higher a while back