### PR TITLE
fix ghost crash "Cannot read property 'match' of undefined"

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -17,7 +17,7 @@ const checkDeprecations = function checkDeprecations(theme, options) {
 
     _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
-            const template = themeFile.file.match(/[^/\\]+.hbs$/);
+            const template = themeFile.file.match(/[^/\\]+\.hbs$/);
             const skipTemplateCheck = check.notValidIn && check.notValidIn.match(template);
             let css = themeFile.file.match(/\.css/);
             let cssDeprecations;


### PR DESCRIPTION
fixes fatal error that results in status 500 errors when theme includes a file that ends in /[^.].hbs/
also fixes that theme fails to activate of theme includes files ending in /[^.].hbs/

Example/to reproduce error: 
Create new theme, and create new file amp.__hbs. 
Observe that ghost crashes if theme is already in use, else theme can't be activated (not error is displayed).
Upon inspecting ghost logs, observe fatal crash in line 26 (`if (themeFile.content.match(check.regex))`) "Cannot read property 'match' of undefined".
This is because content only exists for actual hbs templates and a file ".__hbs" has not been processed as a template.

This change fixes the regex to detect `.hbs` and only `.hbs`

Background: I ran into exactly above described scenario - I wanted to temporarily disable using the `amp.hbs` file, so I renamed it to `amp.__hbs`. I did a whole bunch of other little changes, before I realized that ghost wasn't working anymore, instead displaying me error 500 for every page. A couple of hours later (after re-installing the theme, googling for answers, etc) I found the root cause of this bug, as described above. I was able to fix it for me with either making the change above, or just renaming the file to `amp.hbs` and commenting out all its content.
I hope this PR helps any poor soul running into the same error.