### PR TITLE
Validation Support for @partial-block

### DIFF
--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -112,7 +112,7 @@ module.exports = class BaseRule {
     }
 
     isValidPartialReference(node) {
-        return node.name.original === "@partial-block" ? true : this.partials.includes(node.name.original);
+        return ["@partial-block", ...this.partials].includes(node.name.original);
     }
 
     isValidHelperReference(nodeName) {

--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -112,7 +112,7 @@ module.exports = class BaseRule {
     }
 
     isValidPartialReference(node) {
-        return this.partials.includes(node.name.original);
+        return node.name.original === "@partial-block" ? true : this.partials.includes(node.name.original);
     }
 
     isValidHelperReference(nodeName) {

--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -112,7 +112,7 @@ module.exports = class BaseRule {
     }
 
     isValidPartialReference(node) {
-        return ["@partial-block", ...this.partials].includes(node.name.original);
+        return node.name.original === '@partial-block' || this.partials.includes(node.name.original);
     }
 
     isValidHelperReference(nodeName) {

--- a/test/fixtures/themes/005-compile/canary/invalid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/canary/invalid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}

--- a/test/fixtures/themes/005-compile/canary/valid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/canary/valid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> "@partial-block" }}

--- a/test/fixtures/themes/005-compile/canary/valid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/canary/valid-with-partials/index.hbs
@@ -1,2 +1,2 @@
 {{> "mypartial"}}
-{{> "@partial-block" }}
+{{> @partial-block }}

--- a/test/fixtures/themes/005-compile/v1/invalid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/v1/invalid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}

--- a/test/fixtures/themes/005-compile/v2/invalid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/v2/invalid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}

--- a/test/fixtures/themes/005-compile/v3/invalid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/v3/invalid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}

--- a/test/fixtures/themes/005-compile/v3/valid-with-partials/index.hbs
+++ b/test/fixtures/themes/005-compile/v3/valid-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}

--- a/test/fixtures/themes/theme-with-partials/index.hbs
+++ b/test/fixtures/themes/theme-with-partials/index.hbs
@@ -1,1 +1,2 @@
 {{> "mypartial"}}
+{{> @partial-block }}


### PR DESCRIPTION
Adding support to `isValidPartialReference` check in the AST Linter for the [Handlebars-provided partial `@partial-block`](https://handlebarsjs.com/guide/partials.html#partial-blocks).

Previously the check only compared a node's name against the list of partials defined in the theme's `partials/` directory; have added a static reference to `@partial-block` to be included in this list without requiring it to be present in that directory.