### PR TITLE
Removed blocking lstat calls

### DIFF
--- a/lib/checks/030-assets.js
+++ b/lib/checks/030-assets.js
@@ -1,17 +1,14 @@
 const _ = require('lodash');
-const path = require('path');
-const fs = require('fs');
 const spec = require('../specs');
 const versions = require('../utils').versions;
 
-const checkAssets = function checkAssets(theme, options, themePath) {
+const checkAssets = function checkAssets(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', versions.default);
     const ruleSet = spec.get([checkVersion]);
 
     let ruleToCheck = 'GS030-ASSET-REQ';
     let failures = [];
     let assetMatch;
-    let stats;
 
     _.filter(theme.files, {ext: '.hbs'}).forEach(function (template) {
         try {
@@ -30,19 +27,10 @@ const checkAssets = function checkAssets(theme, options, themePath) {
     }
 
     ruleToCheck = 'GS030-ASSET-SYM';
-    failures = [];
-
-    theme.files.forEach(function (themeFile) {
-        try {
-            stats = fs.lstatSync(path.join(themePath, themeFile.file));
-
-            if (stats.isSymbolicLink()) {
-                failures.push({ref: themeFile.file});
-            }
-        } catch (err) {
-            // ignore
-        }
-    });
+    failures = theme
+        .files
+        .filter(f => f.symlink)
+        .map(f => ({ref: f.file}));
 
     if (failures.length > 0) {
         theme.results.fail[ruleToCheck] = {failures: failures};

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -29,16 +29,18 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
 
     arr = arr || [];
 
-    var makeResult = function makeResult(result, subFilePath, ext) {
+    var makeResult = function makeResult(result, subFilePath, ext, symlink) {
         result.push({
             file: subFilePath,
-            ext: ext
+            ext,
+            symlink
         });
         return result;
     };
 
-    return fs.readdir(themePath).then(function (files) {
-        return Promise.reduce(files, function (result, file) {
+    return fs.readdir(themePath, {withFileTypes: true}).then(function (files) {
+        return Promise.reduce(files, function (result, dirent) {
+            const file = dirent.name;
             var extMatch = file.match(/.*?(\.[0-9a-z]+$)/i),
                 subFilePath = path.join(subPath, file),
                 newPath = path.join(themePath, file);
@@ -60,14 +62,11 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
                     : result;
             }
 
-            // NOTE: lstat does not follow symlinks
-            return fs.lstat(newPath).then(function (statFile) {
-                if (statFile.isDirectory()) {
-                    return readThemeStructure(newPath, subFilePath, result);
-                } else {
-                    return makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined);
-                }
-            });
+            if (dirent.isDirectory()) {
+                return readThemeStructure(newPath, subFilePath, result);
+            } else {
+                return makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());
+            }
         }, arr);
     });
 };

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -9,8 +9,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(96);
@@ -49,8 +49,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(33);
@@ -85,8 +85,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(96);
@@ -121,8 +121,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(99);
@@ -157,8 +157,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -302,8 +302,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(110);
@@ -448,8 +448,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -468,8 +468,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -486,7 +486,7 @@ describe('Checker', function () {
     it('should not follow symlinks', function (done) {
         check(themePath('030-assets/symlink2')).then((theme) => {
             theme.should.be.a.ValidThemeObject();
-            theme.files.should.containEql({file: 'assets/mysymlink', ext: undefined});
+            theme.files.should.containEql({file: 'assets/mysymlink', ext: undefined, symlink: true});
             theme.results.fail.should.have.ownProperty('GS030-ASSET-SYM');
 
             done();

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -21,8 +21,8 @@ describe('Read theme', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep'},
-                {file: 'README.md', ext: '.md'}
+                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', ext: '.md', symlink: false}
             ]);
             done();
         }).catch(done);


### PR DESCRIPTION
- `lstatSync` is a blocking call to the filesystem and may block the
  process when the underlying filesystem is slow
- by this point in the code, we've already done async lstat calls once
  because we've traversed the theme folder to find and load the files
- so basically, we're doing superfluous blocking calls for the fun of it 🙈
- this commit adds the necessary data re: symlinks into the list of
  files we initially build up, alters the code to use this data and
  removes the blocking calls