### PR TITLE
Updated check for deprecated @price usage

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -76,6 +76,7 @@ let rules = {
         details: oneLineTrim`The <code>{{@price}}</code> data helper was removed in favor of <code>{{price}}</code> and <code>{{@member.subscriptions}}</code><br>
         ${tierDesc}<br>
         Find more information about the <code>{{price}}</code> helper <a href="${docsBaseUrl}members/#the-price-helper" target=_blank>here</a>.`,
+        regex: /{{[\s\S]*?@price[\s\S]*?}}/g,
         helper: '{{@price}}'
     },
     'GS090-NO-TIER-PRICE-AS-OBJECT': {


### PR DESCRIPTION
The `@price` data helper was only checked when used as a standalone helper - `{{@price.monthly}}`. This wasn't taking into account other usages of `@price` inside other helpers like - `{{price @price.monthly}} or `{{price currency=@price.currency}}` which are also invalid usages.

- expands `@price` check to use regex and flag any usage of `@price` inside the helper brackets