### PR TITLE
Added workflow to check links in docs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,24 @@
+name: Check Links
+on:
+  workflow_dispatch: # Manual checks
+  schedule:
+    - cron: 31 13 * * 2 # 13:31 on Tuesdays
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: lts/*
+          cache: yarn
+
+      - run: yarn
+      - run: node test/valid-doc-links.js

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-ghost": "2.1.0",
     "istanbul": "0.4.5",
     "mocha": "10.0.0",
+    "node-fetch": "v2",
     "nodemon": "2.0.7",
     "rewire": "6.0.0",
     "should": "13.2.3",

--- a/test/valid-doc-links.js
+++ b/test/valid-doc-links.js
@@ -1,0 +1,234 @@
+// @ts-check
+/* eslint-disable no-console */
+const path = require('path');
+const glob = require('glob');
+const chalk = require('chalk');
+const {default: fetch} = require('node-fetch');
+
+const checkIds = process.env.GSCAN_DOC_CHECK_IDS !== 'false';
+
+const SPEC_ROOT = path.resolve(__dirname, '../lib/specs/');
+
+class Semaphore {
+    /**
+     * @param {number} maximum
+     * @param {number} delay
+     */
+    constructor(maximum, delay = 150) {
+        this._maximum = maximum;
+        this._delay = delay;
+        this._activeCount = 0;
+        this._queue = [];
+
+        // @TODO: Make this a public class property once ESLint supports it
+        this._release = () => {
+            this._activeCount -= 1;
+
+            if (this._queue.length > 0) {
+                setTimeout(this._queue.shift(), this._delay, this._release);
+            }
+        };
+    }
+
+    acquire() {
+        if (this._activeCount === this._maximum) {
+            const response = new Promise((resolve) => {
+                this._queue.push(resolve);
+            });
+
+            return response;
+        }
+
+        this._activeCount += 1;
+        return this._release;
+    }
+}
+
+const LINK_TAG_EXTRACTION_REGEX = /<a\s(.*?)>/g;
+const LINK_EXTRACTION_REGEX = /href="(.*?)"/g;
+
+/**
+ * @param {string} linkTag
+ * @param {string} rulePath
+ * @param {Record<string, Set<string>>} linksToCheck
+ * @param {Record<string, Set<string>>} idsToCheck
+ */
+function extractLinksAndIssues(linkTag, rulePath, linksToCheck, idsToCheck) {
+    const errorList = [];
+
+    // @TODO: Should `target=_blank` be allowed?
+    if (!linkTag.includes('target="_blank"') && !linkTag.includes('target=_blank')) {
+        errorList.push('Does not have target="_blank"');
+    }
+
+    const [extractedLink] = linkTag.matchAll(LINK_EXTRACTION_REGEX);
+
+    if (extractedLink) {
+        try {
+            const parsedLink = new URL(extractedLink[1]);
+            const {hash} = parsedLink;
+            parsedLink.hash = '';
+            const link = parsedLink.toString();
+
+            if (parsedLink.hostname.endsWith('ghost.org')) {
+                // @TODO: Node 16 linksToCheck[link] ??= new Set();
+                linksToCheck[link] = linksToCheck[link] || new Set();
+                linksToCheck[link].add(rulePath);
+
+                if (checkIds && hash.length > 1) {
+                    idsToCheck[link] = idsToCheck[link] || new Set();
+                    // @TODO: Node 16 idsToCheck[link] ??= new Set();
+                    idsToCheck[link].add(hash.slice(1));
+                }
+            } else {
+                errorList.push('Has an href that is not part of the Ghost website');
+            }
+        } catch (_) { // @TODO: Remove Catch Binding when eslint supports it
+            errorList.push('Has an href with an invalid URL');
+        }
+    } else {
+        errorList.push('Does not contain an href');
+    }
+
+    return errorList;
+}
+
+/**
+ * @param {string} url
+ * @param {Semaphore} semaphore
+ * @param {Set<string>} dependencies
+ * @param {null | Set<string>} idsToCheck
+ */
+async function confirmUrl(url, semaphore, dependencies, idsToCheck) {
+    const releaseLock = await semaphore.acquire();
+    const start = Date.now();
+
+    try {
+        const method = idsToCheck ? 'GET' : 'HEAD';
+        const returnValue = {
+            url,
+            dependencies,
+            success: false,
+            hasRedirect: false,
+            statusCode: null,
+            missingIds: []
+        };
+
+        const response = await fetch(url, {method});
+        returnValue.hasRedirect = response.redirected;
+        returnValue.statusCode = response.status;
+
+        if (!response.ok) {
+            returnValue.success = false;
+            return returnValue;
+        }
+
+        if (!idsToCheck) {
+            returnValue.success = true;
+            return returnValue;
+        }
+
+        const body = await response.text();
+
+        for (const id of idsToCheck) {
+            if (!body.includes(`id="${id}"`) && !body.includes(`id=${id}`)) {
+                returnValue.missingIds.push(id);
+            }
+        }
+
+        returnValue.success = returnValue.missingIds.length === 0;
+
+        return returnValue;
+    } finally {
+        releaseLock();
+        const elapsed = Date.now() - start;
+        console.log(`Test: ${url} (${chalk.cyan(elapsed + 'ms')})`);
+    }
+}
+
+/**
+ * @param {Awaited<ReturnType<confirmUrl>>[]} summaries
+ * @param {Record<string, string[]>} otherErrors
+ */
+function summarize(summaries, otherErrors) {
+    let failureCount = 0;
+    for (const summary of summaries) {
+        const uses = summary.dependencies.size === 1
+            ? `in ${summary.dependencies.values().next().value}`
+            : `${summary.dependencies.size}x`;
+        const urlWithUse = `${chalk.cyan(summary.url)} (used ${uses})`;
+        if (summary.success) {
+            if (summary.hasRedirect) {
+                console.log(`${urlWithUse} was ${chalk.yellow('redirected')}`);
+            }
+
+            continue;
+        }
+
+        failureCount += 1;
+
+        if (summary.missingIds.length === 0) {
+            console.log(`${urlWithUse} returned a ${chalk.red('not-ok')} (${summary.statusCode}) status.`);
+            continue;
+        }
+
+        console.log(`${urlWithUse} is ${chalk.yellow('missing')} ${summary.missingIds.length} ids:`);
+        console.log(summary.missingIds.map(id => `  - ${id}`).join('\n'));
+    }
+
+    const otherErrorKV = Object.entries(otherErrors);
+
+    if (otherErrorKV.length === 0) {
+        return failureCount;
+    }
+
+    const plural = otherErrorKV.length === 1 ? '1 rule' : `${otherErrorKV.length} rules`;
+
+    console.log(`${plural} have errors:`);
+
+    for (const [ruleName, errors] of otherErrorKV) {
+        console.log('  %s', ruleName);
+        console.log(errors.map(error => `    ${error}`).join('\n'));
+    }
+
+    failureCount += otherErrorKV.length;
+
+    return failureCount;
+}
+
+const semaphore = new Semaphore(5);
+
+async function run() {
+    const allSpecs = glob.sync('*.js', {cwd: SPEC_ROOT, ignore: 'index.js'});
+
+    /** @type {Record<string, Set<string>>} */
+    const linksToCheck = {};
+    /** @type {Record<string, Set<string>>} */
+    const idsToCheck = {};
+    /** @type {Record<string, string[]>} */
+    const miscErrors = {};
+
+    for (const specFileName of allSpecs) {
+        const {rules} = require(`../lib/specs/${specFileName}`);
+        for (const [ruleName, {details: textWithPossibleLinks}] of Object.entries(rules)) {
+            for (const match of textWithPossibleLinks.matchAll(LINK_TAG_EXTRACTION_REGEX)) {
+                const fullRuleName = `${specFileName.split('.').shift()}/${ruleName}`;
+                const errors = extractLinksAndIssues(match[0], fullRuleName, linksToCheck, idsToCheck);
+
+                if (errors.length > 0) {
+                    miscErrors[fullRuleName] = errors;
+                }
+            }
+        }
+    }
+
+    const summary = await Promise.all(
+        Object.entries(linksToCheck).map(
+            ([url, dependencies]) => confirmUrl(url, semaphore, dependencies, idsToCheck[url] || null)
+        )
+    );
+
+    process.exit(summarize(summary, miscErrors));
+}
+
+run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,13 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@v2:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-loggly-bulk@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/node-loggly-bulk/-/node-loggly-bulk-2.2.5.tgz#6f41136f91b363d1b50612e8be0063859226967e"
@@ -3712,6 +3719,11 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -3999,6 +4011,19 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^1.1.1, which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
no issue

Added a little test to extract the links in the `details` property of a rule. Not part of the official test suite since it hits `ghost.org` a bunch.
 - Configured to run weekly
 - Can also be manually triggered

This is a very basic starting point that can be expanded as needed 😊

Things it does:
- Ensure `a` tag has a link, and that link points to a WHATWG-compliant URL
- Ensure `a` tag contains `target="_blank"`
- Ensure links point to a `ghost.org` site
- Ensure links are not redirected (non-fatal)
- Ensure IDs referenced in a link are valid
- self-rate-limits (5 URLs / 150ms right now)

Things it doesn't do:
- Tell you where a link was redirected
- Dedupe rule list - we could get away with only handling new rules of a test suite, but I didn't want to change existing files in this PR.

Things it could do in the future:
- Only extract the list of URLs + IDs that are referenced
- More validation checks

```
Test: https://ghost.org/docs/themes/helpers/pagination/ (71ms)
Test: https://ghost.org/docs/themes/helpers/meta_data/ (63ms)
Test: https://ghost.org/docs/themes/helpers/ghost_head_foot/ (153ms)
Test: https://ghost.org/docs/themes/helpers/img_url/ (179ms)
Test: https://ghost.org/docs/themes/contexts/ (200ms)
Test: https://ghost.org/docs/themes/contexts/author/ (74ms)
Test: https://ghost.org/docs/themes/helpers/site/ (156ms)
Test: https://ghost.org/docs/themes/contexts/post/ (79ms)
Test: https://ghost.org/docs/themes/helpers/config/ (55ms)
Test: https://ghost.org/docs/themes/contexts/tag/ (77ms)
Test: https://ghost.org/docs/themes/structure/ (75ms)
Test: https://ghost.org/docs/themes/helpers/foreach/ (62ms)
Test: https://ghost.org/docs/themes/helpers/ (74ms)
Test: https://ghost.org/docs/themes/contexts/index-context/ (56ms)
Test: https://ghost.org/docs/themes/helpers/asset/ (145ms)
Test: https://ghost.org/docs/themes/helpers/get/ (179ms)
Test: https://ghost.org/docs/themes//helpers/ (138ms)
Test: https://ghost.org/docs/themes/helpers/authors/ (173ms)
Test: https://ghost.org/docs/changes/ (58ms)
Test: https://ghost.org/docs/themes/helpers/tiers/ (57ms)
Test: https://ghost.org/docs/themes/helpers/price/ (56ms)
Test: https://ghost.org/docs/themes/content/ (410ms)
Test: https://ghost.org/docs/themes/members/ (226ms)
Test: https://ghost.org/docs/themes/helpers/labs/ (68ms)
Test: https://ghost.org/docs/themes/helpers/price (352ms)
https://ghost.org/docs/themes//helpers/ (used 4x) was redirected
https://ghost.org/docs/themes/helpers/price (used in canary/GS001-DEPR-CURR-SYM) was redirected
https://ghost.org/docs/themes/helpers/labs/ (used in v4/GS001-DEPR-LABS-MEMBERS) returned a not-ok (404) status.
5 rules have errors:
  canary/GS010-PJ-PARSE
    Has an href that is not part of the Ghost website
  v1/GS010-PJ-PARSE
    Has an href that is not part of the Ghost website
  v2/GS010-PJ-PARSE
    Has an href that is not part of the Ghost website
  v3/GS010-PJ-PARSE
    Has an href that is not part of the Ghost website
  v4/GS010-PJ-PARSE
    Has an href that is not part of the Ghost website
```