### PR TITLE
Too many S's

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -15,7 +15,7 @@ const authorHelperDocs = `Find more information about the <code>{{authors}}</cod
 const tierDesc = `Ghost now supports multiple tiers and subscriptions. All product and price related helpers have been reworked to account for this.`;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = ['total_members', 'total_paid_memberss'];
+let knownHelpers = ['total_members', 'total_paid_members'];
 let templates = [];
 let rules = {
     // New rules


### PR DESCRIPTION
Should be 'total_paid_members' rather than 'total_paid_memberss'?