### PR TITLE
Update error for missing koenig styles

### DIFF
--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -63,7 +63,7 @@ const checkKoenigCssClasses = function checkKoenigCssClasses(theme, options) {
             theme.results.fail[ruleCode] = {};
             theme.results.fail[ruleCode].failures = [
                 {
-                    ref: 'Missing styles or stylesheets'
+                    ref: 'Missing stylesheets with required class styles'
                 }
             ];
         }

--- a/lib/checks/050-koenig-css-classes.js
+++ b/lib/checks/050-koenig-css-classes.js
@@ -63,7 +63,7 @@ const checkKoenigCssClasses = function checkKoenigCssClasses(theme, options) {
             theme.results.fail[ruleCode] = {};
             theme.results.fail[ruleCode].failures = [
                 {
-                    ref: 'styles'
+                    ref: 'Missing styles or stylesheets'
                 }
             ];
         }

--- a/test/050-koenig-css-classes.test.js
+++ b/test/050-koenig-css-classes.test.js
@@ -41,11 +41,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
 
                 done();
             }).catch(done);
@@ -121,11 +121,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
 
                 done();
             }).catch(done);
@@ -201,11 +201,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
 
                 done();
             }).catch(done);
@@ -311,8 +311,8 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGWF'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGWW'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing stylesheets with required class styles');
 
                 done();
             }).catch(done);

--- a/test/050-koenig-css-classes.test.js
+++ b/test/050-koenig-css-classes.test.js
@@ -41,11 +41,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('styles');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
 
                 done();
             }).catch(done);
@@ -121,11 +121,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('styles');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
 
                 done();
             }).catch(done);
@@ -201,11 +201,11 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGGR'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGGI'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('styles');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGC'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGR'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGGI'].failures[0].ref.should.eql('Missing styles or stylesheets');
 
                 done();
             }).catch(done);
@@ -311,8 +311,8 @@ describe('050 Koenig CSS classes', function () {
                 output.results.fail['GS050-CSS-KGWF'].failures.length.should.eql(1);
                 output.results.fail['GS050-CSS-KGWW'].failures.length.should.eql(1);
 
-                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('styles');
-                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('styles');
+                output.results.fail['GS050-CSS-KGWF'].failures[0].ref.should.eql('Missing styles or stylesheets');
+                output.results.fail['GS050-CSS-KGWW'].failures[0].ref.should.eql('Missing styles or stylesheets');
 
                 done();
             }).catch(done);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/48868107/203095068-8efd0133-03fd-48e4-ae87-177e8d864a95.png)

When recently helping a customer update to v5, Jon got hit with this error message, which he found confusing for him and the customer. In particular, the bit about `affected files: styles`. The difficulty here is that the error message is not about a specific file  — but about missing files.

This commit updates the error message to be more explicit:
`Missing styles or stylesheets`
