### PR TITLE
update error msg when passing zip without flag

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -113,8 +113,10 @@ prettyCLI
             gscan.check(argv.themePath, cliOptions)
                 .then(theme => outputResults(theme, cliOptions))
                 .catch((err) => {
-                    ui.log(`\n${chalk.red(err.message)}`);
-                    err.code === 'ENOTDIR' && ui.log('Did you mean to add the -z flag to read a zip file?');
+                    ui.log(err.message);
+                    if (err.code === 'ENOTDIR') {
+                        ui.log('Did you mean to add the -z flag to read a zip file?');
+                    }
                 });
         }
     });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -112,11 +112,9 @@ prettyCLI
         } else {
             gscan.check(argv.themePath, cliOptions)
                 .then(theme => outputResults(theme, cliOptions))
-                .catch(function ENOTDIRPredicate(err) {
-                    return err.code === 'ENOTDIR';
-                }, function (err) {
-                    ui.log(err.message);
-                    ui.log('Did you mean to add the -z flag to read a zip file?');
+                .catch((err) => {
+                    ui.log(`\n${chalk.red(err.message)}`);
+                    err.code === 'ENOTDIR' && ui.log('Did you mean to add the -z flag to read a zip file?');
                 });
         }
     });


### PR DESCRIPTION
Ref #465 

When passing a zip file to gscan without including the `-z` flag, gscan currently quits without logging the error, which is confusing to users.

This change logs the error to the console, and, if the error is because the path passed is not a dir, then provides a hint about the `z` flag.