### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "IMAGE_VERSION=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Publish to DigitalOcean Registry
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: ${{ env.REGISTRY }}
           name: ${{ env.NAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore