### PR TITLE
✨ Added rule for custom setting description length

### DIFF
--- a/lib/checks/010-package-json.js
+++ b/lib/checks/010-package-json.js
@@ -57,6 +57,7 @@ const v4PackageJSONValidationRules = _.extend({},
 const canaryPackageJSONConditionalRules = {};
 const canaryPackageJSONValidationRules = _.extend({},
     {isNotPresentCardAssets: 'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT'},
+    {invalidCustomThemeSettingDescriptionLength: 'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'},
     canaryPackageJSONConditionalRules
 );
 
@@ -196,6 +197,10 @@ _private.validatePackageJSONFields = function validatePackageJSONFields(packageJ
                 break;
             default:
                 //do nothing here
+            }
+
+            if (entry.description && entry.description.length > 100) {
+                markFailed('invalidCustomThemeSettingDescriptionLength');
             }
         }
     }

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -706,6 +706,12 @@ let rules = {
         Find more information about the updated <code>{{price}}</code> helper <a href="${docsBaseUrl}helpers/price/" target=_blank>here</a>.`,
         helper: '{{[#].currency_symbol}}',
         regex: /currency_symbol/g
+    },
+    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH': {
+        level: 'warning',
+        rule: '<code>package.json</code> property <code>config.custom</code> contains an entry with a <code>description</code> that is too long',
+        details: oneLineTrim`<code>config.custom</code> entry <code>description</code> should be less than <code>100</code> characters so that it is displayed correctly.<br />
+        Check the <a href="${docsBaseUrl}custom-settings" target=_blank><code>config.custom</code> documentation</a> for further information.`
     }
 };
 

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -666,7 +666,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CUST-THEME-SETTINGS-BOOLEAN-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-COLOR-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT',
-                    'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT'
+                    'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT',
+                    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'
                 ]);
 
                 theme.results.fail.should.be.an.Object().which.is.empty();
@@ -694,7 +695,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CUST-THEME-SETTINGS-BOOLEAN-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-COLOR-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT',
-                    'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT'
+                    'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT',
+                    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'
                 ]);
 
                 Object.keys(theme.results.fail).should.eql([
@@ -729,7 +731,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CUST-THEME-SETTINGS-SELECT-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-BOOLEAN-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-COLOR-DEFAULT',
-                    'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT'
+                    'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT',
+                    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'
                 ]);
 
                 theme.results.fail.should.be.an.Object().with.keys(
@@ -782,7 +785,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CUST-THEME-SETTINGS-TYPE',
                     'GS010-PJ-CUST-THEME-SETTINGS-GROUP',
                     'GS010-PJ-CUST-THEME-SETTINGS-SELECT-OPTIONS',
-                    'GS010-PJ-CUST-THEME-SETTINGS-SELECT-DEFAULT'
+                    'GS010-PJ-CUST-THEME-SETTINGS-SELECT-DEFAULT',
+                    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'
                 );
 
                 done();
@@ -815,7 +819,8 @@ describe('010 package.json', function () {
                     'GS010-PJ-CUST-THEME-SETTINGS-SELECT-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-BOOLEAN-DEFAULT',
                     'GS010-PJ-CUST-THEME-SETTINGS-COLOR-DEFAULT',
-                    'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT'
+                    'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT',
+                    'GS010-PJ-CUST-THEME-SETTINGS-DESCRIPTION-LENGTH'
                 ]);
 
                 done();

--- a/test/fixtures/themes/010-packagejson/invalid-custom-theme/package.json
+++ b/test/fixtures/themes/010-packagejson/invalid-custom-theme/package.json
@@ -36,21 +36,22 @@
         "options": ["one", "two"],
         "default": "three"
       },
-      "too_many_settings0": {
-        "type": "color"
+      "description_too_long": {
+        "type": "color",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor."
       },
-      "too_many_settings1": {
+      "too_many_settings0": {
         "type": "image",
         "default": "test"
       },
+      "too_many_settings1": {},
       "too_many_settings2": {},
       "too_many_settings3": {},
       "too_many_settings4": {},
       "too_many_settings5": {},
       "too_many_settings6": {},
       "too_many_settings7": {},
-      "too_many_settings8": {},
-      "too_many_settings9": {}
+      "too_many_settings8": {}
     }
   }
 }

--- a/test/fixtures/themes/010-packagejson/valid-custom-theme/package.json
+++ b/test/fixtures/themes/010-packagejson/valid-custom-theme/package.json
@@ -31,7 +31,8 @@
         "default": "one"
       },
       "title": {
-        "type": "text"
+        "type": "text",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quisquam, voluptatem."
       }
     }
   }

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -380,7 +380,7 @@ describe('Format', function () {
                 theme.results.recommendation.all.length.should.eql(2);
                 theme.results.recommendation.byFiles['package.json'].length.should.eql(2);
 
-                theme.results.warning.all.length.should.eql(5);
+                theme.results.warning.all.length.should.eql(6);
                 theme.results.warning.byFiles['default.hbs'].length.should.eql(2);
 
                 theme.results.error.all.length.should.eql(21);
@@ -413,7 +413,7 @@ describe('Format', function () {
                 theme.results.recommendation.byFiles['package.json'].length.should.eql(2);
 
                 theme.results.error.all.length.should.eql(103);
-                theme.results.warning.all.length.should.eql(7);
+                theme.results.warning.all.length.should.eql(8);
 
                 const errorErrors = theme.results.error.all
                     .filter(error => (error.level === 'error') && !error.fatal);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3448

Custom setting descriptions are limited to 100 characters to prevent overly long custom setting descriptions from diminishing the settings UX in Ghost admin