### PR TITLE
Removed unused bluebird Promise import from read-zip.js

### DIFF
--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -1,6 +1,5 @@
 const debug = require('@tryghost/debug')('zip');
 const path = require('path');
-const Promise = require('bluebird');
 const os = require('os');
 const glob = require('glob');
 const {extract} = require('@tryghost/zip');


### PR DESCRIPTION
Removed unused bluebird Promise import from read-zip.js for https://github.com/TryGhost/Ghost/issues/14882
