### PR TITLE
Added rules for `@page` property usage

### DIFF
--- a/lib/ast-linter/linter.js
+++ b/lib/ast-linter/linter.js
@@ -20,6 +20,7 @@ class Linter {
         this.helpers = [];
         this.inlinePartials = [];
         this.customThemeSettings = [];
+        this.usedPageProperties = [];
     }
 
     /**
@@ -57,7 +58,8 @@ class Linter {
                 partials: [],
                 helpers: [],
                 inlinePartials: [],
-                customThemeSettings: []
+                customThemeSettings: [],
+                usedPageProperties: []
             };
         }
         Scanner.prototype = new Handlebars.Visitor();
@@ -159,6 +161,10 @@ class Linter {
 
         if (scanner.context.inlinePartials) {
             this.inlinePartials = scanner.context.inlinePartials;
+        }
+
+        if (scanner.context.usedPageProperties) {
+            this.usedPageProperties = scanner.context.usedPageProperties;
         }
 
         return messages;

--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -9,6 +9,8 @@ module.exports = class BaseRule {
         this.helpers = options.helpers;
         this.inlinePartials = options.inlinePartials || [];
         this.customThemeSettings = options.customThemeSettings;
+        // TODO: remove hardcoded list of known page builder properties once we have a way to get them from the spec
+        this.knownPageBuilderProperties = options.knownPageBuilderProperties || ['show_title_and_feature_image'];
     }
 
     getVisitor({fileName} = {}) {
@@ -158,6 +160,10 @@ module.exports = class BaseRule {
 
     isValidHelperReference(nodeName) {
         return this.helpers && this.helpers.includes(nodeName);
+    }
+
+    isValidPageBuilderProperty(property) {
+        return this.knownPageBuilderProperties && this.knownPageBuilderProperties.includes(property);
     }
 
     isValidCustomThemeSettingReference(name) {

--- a/lib/ast-linter/rules/index.js
+++ b/lib/ast-linter/rules/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'GS090-NO-PRICE-DATA-CURRENCY-GLOBAL': require('./lint-no-price-data-currency-global'),
     'GS090-NO-PRICE-DATA-CURRENCY-CONTEXT': require('./lint-no-price-data-currency-context'),
     'GS090-NO-PRICE-DATA-MONTHLY-YEARLY': require('./lint-no-price-data-monthly-yearly'),
+    'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': require('./lint-no-unknown-page-properties'),
     'no-multi-param-conditionals': require('./lint-no-multi-param-conditionals'),
     'no-nested-async-helpers': require('./lint-no-nested-async-helpers'),
     'no-prev-next-post-outside-post-context': require('./lint-no-prev-next-post-outside-post-context'),

--- a/lib/ast-linter/rules/lint-no-unknown-page-properties.js
+++ b/lib/ast-linter/rules/lint-no-unknown-page-properties.js
@@ -1,0 +1,21 @@
+const Rule = require('./base');
+const {logNode} = require('../helpers');
+
+module.exports = class NoUnknownPageProperties extends Rule {
+    _checkForUnknownPageProperty(node) {
+        if (node.data && node.parts && node.parts[0] === 'page' && (node.parts.length > 2 || !this.isValidPageBuilderProperty(node.parts[1]))) {
+            this.log({
+                message: `${logNode(node)} is not a known @page property`,
+                line: node.loc && node.loc.start.line,
+                column: node.loc && node.loc.start.column,
+                source: this.sourceForNode(node)
+            });
+        }
+    }
+
+    visitor() {
+        return {
+            PathExpression: this._checkForUnknownPageProperty.bind(this)
+        };
+    }
+};

--- a/lib/ast-linter/rules/mark-used-page-properties.js
+++ b/lib/ast-linter/rules/mark-used-page-properties.js
@@ -1,0 +1,15 @@
+const Rule = require('./base');
+
+module.exports = class MarkUsedPageProperties extends Rule {
+    _markUsedPageProperties(node) {
+        if (node.data && node.parts && node.parts.length === 2 && node.parts[0] === 'page') {
+            this.scanner.context.usedPageProperties.push(node.parts[1]);
+        }
+    }
+
+    visitor() {
+        return {
+            PathExpression: this._markUsedPageProperties.bind(this)
+        };
+    }
+};

--- a/lib/checks/090-template-syntax.js
+++ b/lib/checks/090-template-syntax.js
@@ -73,6 +73,7 @@ const checkTemplateSyntax = function checkTemplateSyntax(theme, options) {
 
         const linter = new ASTLinter({
             partials: theme.partials,
+            inlinePartials: [],
             helpers: [],
             customThemeSettings: customThemeSettings
         });

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -1,0 +1,185 @@
+const _ = require('lodash');
+const spec = require('../specs');
+const {versions, normalizePath} = require('../utils');
+const ASTLinter = require('../ast-linter');
+
+function getRules(id, options) {
+    const checkVersion = _.get(options, 'checkVersion', versions.default);
+    let ruleSet = spec.get([checkVersion]);
+
+    const ruleRegex = new RegExp('^' + id + '-.*', 'g');
+    ruleSet = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
+        if (ruleCode.match(ruleRegex)) {
+            return rule;
+        }
+    });
+
+    return ruleSet;
+}
+
+function getLogger({theme, rule, file = null}) {
+    return {
+        failure: (content) => {
+            if (!theme.results.fail[rule.code]) {
+                theme.results.fail[rule.code] = {failures: []};
+            }
+            const failure = {
+                ...content,
+                rule: rule.code
+            };
+            if (file) {
+                failure.ref = file.file;
+            }
+            theme.results.fail[rule.code].failures.push(failure);
+        }
+    };
+}
+
+function applyRule(rule, theme) {
+    // The result variable is passed around to keep a state through the full lifecycle
+    const result = {};
+    try {
+        // Check if the rule is enabled (optional)
+        if (typeof rule.isEnabled === 'function') {
+            if (!rule.isEnabled({theme, log: getLogger({theme, rule}), result, options: rule.options})) {
+                return;
+            }
+        } else if (typeof rule.isEnabled === 'boolean' && !rule.isEnabled) {
+            return;
+        }
+
+        // Initialize the rule (optional)
+        if (typeof rule.init === 'function') {
+            rule.init({theme, log: getLogger({theme, rule}), result});
+        }
+
+        // Run the main function on each theme file (optional)
+        if (typeof rule.eachFile === 'function') {
+            _.each(theme.files, function (themeFile) {
+                rule.eachFile({file: themeFile, theme, log: getLogger({theme, rule}), result});
+            });
+        }
+
+        // Run the final function
+        if (typeof rule.done === 'function') {
+            rule.done({theme, log: getLogger({theme, rule}), result});
+        }
+    } catch (e) {
+        // Output something instead of failing silently (should never happen)
+        // eslint-disable-next-line
+        console.error('gscan failure', e);
+    }
+}
+
+function parseWithAST({theme, log, file, rules, callback}) {
+    const linter = new ASTLinter();
+
+    // // This rule is needed to find partials
+    // // Partials are needed for a full parsing
+    if (!rules['mark-used-partials']) {
+        rules['mark-used-partials'] = require(`../ast-linter/rules/mark-used-partials`);
+    }
+
+    function processFile(themeFile) {
+        if (themeFile.parsed.error) {
+            // Ignore parsing errors, they are handled in 005
+            return;
+        }
+
+        const astResults = linter.verify({
+            parsed: themeFile.parsed,
+            rules,
+            source: themeFile.content,
+            moduleId: themeFile.file
+        });
+
+        if (astResults.length) {
+            log.failure({
+                message: astResults[0].message
+            });
+        }
+
+        if (typeof callback === 'function') {
+            callback(linter);
+        }
+
+        linter.partials.forEach(({node: partial}) => {
+            const partialFile = theme.files.find(f => normalizePath(f.file) === `partials/${normalizePath(partial)}.hbs`);
+            if (partialFile) {
+                processFile(partialFile);
+            }
+        });
+    }
+
+    return processFile(file);
+}
+
+const ruleImplementations = {
+    'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
+        isEnabled: ({options}) => {
+            // TODO: change to `isEnabled: true` when removing labs flag
+            return options && options.labs && options.labs.pageImprovements;
+        },
+        init: ({result}) => {
+            result.pageBuilderProperties = new Set();
+        },
+        eachFile: ({file, theme, log, result}) => {
+            const templateTest = file.file.match(/(?<!partials\/.+?)\.hbs$/);
+
+            if (templateTest) {
+                parseWithAST({file, theme, rules: {
+                    'mark-used-page-properties': require(`../ast-linter/rules/mark-used-page-properties`)
+                }, log, callback: (linter) => {
+                    linter.usedPageProperties.forEach((variable) => {
+                        result.pageBuilderProperties.add(variable);
+                    });
+                }});
+            }
+        },
+        done: ({log, result}) => {
+            // TODO: get this from the spec rather than hard-coding to account for version changes
+            const knownPageBuilderProperties = ['show_title_and_feature_image'];
+            const notUsedProperties = knownPageBuilderProperties.filter(x => !result.pageBuilderProperties.has(x));
+
+            notUsedProperties.forEach((property) => {
+                log.failure({
+                    ref: `@page.${property}`
+                });
+            });
+        }
+    },
+    'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
+        isEnabled: ({options}) => {
+            // TODO: change to `isEnabled: true` when removing labs flag
+            return options && options.labs && options.labs.pageImprovements;
+        },
+        eachFile: ({file, theme, log}) => {
+            const templateTest = file.file.match(/(?<!partials\/.+?)\.hbs$/);
+
+            if (templateTest) {
+                parseWithAST({
+                    file, theme, rules: {
+                        'no-unknown-page-properties': require(`../ast-linter/rules/lint-no-unknown-page-properties`)
+                    }, log, callback: () => {}
+                });
+            }
+        }
+    }
+};
+
+function checkUsage(theme, options) {
+    const rules = getRules('GS110', options);
+
+    _.each(rules, function (check, ruleCode) {
+        applyRule({
+            code: ruleCode,
+            ...check,
+            ...ruleImplementations[ruleCode],
+            options
+        }, theme);
+    });
+
+    return theme;
+}
+
+module.exports = checkUsage;

--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -712,6 +712,21 @@ let rules = {
         rule: '<code>package.json</code> property <code>config.custom</code> contains an entry with a <code>description</code> that is too long',
         details: oneLineTrim`<code>config.custom</code> entry <code>description</code> should be less than <code>100</code> characters so that it is displayed correctly.<br />
         Check the <a href="${docsBaseUrl}custom-settings" target=_blank><code>config.custom</code> documentation</a> for further information.`
+    },
+
+    'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
+        level: 'warning',
+        rule: 'Not all page builder features are being used',
+        // TODO: get proper docs link
+        details: oneLineTrim`Some page builder features used via the <code>{{@page}}</code> global are not being used.&nbsp;
+        Check the <a href="${docsBaseUrl}page-builder" target=_blank>page builder documentation</a> for further information.`
+    },
+
+    'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
+        level: 'error',
+        fatal: true,
+        rule: 'Unsupported page builder feature used',
+        details: oneLineTrim`A page builder feature used via the <code>{{@page}}</code> global was detected but it's not supported by this version of Ghost.`
     }
 };
 

--- a/test/110-page-builder-usage.test.js
+++ b/test/110-page-builder-usage.test.js
@@ -1,0 +1,44 @@
+var should = require('should'), // eslint-disable-line no-unused-vars
+    utils = require('./utils'),
+    thisCheck = require('../lib/checks/110-page-builder-usage');
+
+describe('110 Page-builder usage', function () {
+    describe('v5', function () {
+        // TODO: remove labs flag here when GA
+        const options = {checkVersion: 'v5', labs: {pageImprovements: true}};
+
+        it('should fail with missing @page.show_title_and_feature_image', async function () {
+            const output = await utils.testCheck(thisCheck, '110-page-builder/invalid/missing-page-usage', options);
+
+            Object.keys(output.results.fail).should.eql([
+                'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
+            ]);
+
+            output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures.should.eql([
+                {ref: '@page.show_title_and_feature_image', rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'}
+            ]);
+        });
+
+        it('should pass with @page.show_title_and_feature_image in top-level template', async function () {
+            const output = await utils.testCheck(thisCheck, '110-page-builder/valid/usage-in-template', options);
+            output.should.be.a.ValidThemeObject();
+
+            Object.keys(output.results.fail).should.eql([]);
+        });
+
+        it('should pass with @page.show_title_and_feature_image in partial', async function () {
+            const output = await utils.testCheck(thisCheck, '110-page-builder/valid/usage-in-partial', options);
+            output.should.be.a.ValidThemeObject();
+
+            Object.keys(output.results.fail).should.eql([]);
+        });
+
+        it('should fail with unknown @page properties', async function () {
+            const output = await utils.testCheck(thisCheck, '110-page-builder/invalid/unknown-page-properties', options);
+
+            Object.keys(output.results.fail).should.eql([
+                'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE'
+            ]);
+        });
+    });
+});

--- a/test/fixtures/themes/110-page-builder/invalid/missing-page-usage/default.hbs
+++ b/test/fixtures/themes/110-page-builder/invalid/missing-page-usage/default.hbs
@@ -1,0 +1,12 @@
+<html>
+
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
+</head>
+
+<body>
+
+</body>
+
+</html>

--- a/test/fixtures/themes/110-page-builder/invalid/unknown-page-properties/default.hbs
+++ b/test/fixtures/themes/110-page-builder/invalid/unknown-page-properties/default.hbs
@@ -1,0 +1,18 @@
+<html>
+
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
+</head>
+
+<body>
+    {{#match @page.show_title_and_feature_image}}
+        <p>@page.show_title_and_feature_image matched</p>
+    {{/match}}
+
+    {{#match @page.not_known}}
+        <p>@page.not_known matched</p>
+    {{/match}}
+</body>
+
+</html>

--- a/test/fixtures/themes/110-page-builder/valid/usage-in-partial/default.hbs
+++ b/test/fixtures/themes/110-page-builder/valid/usage-in-partial/default.hbs
@@ -1,0 +1,12 @@
+<html>
+
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
+</head>
+
+<body>
+    {{> "header"}}
+</body>
+
+</html>

--- a/test/fixtures/themes/110-page-builder/valid/usage-in-partial/partials/header.hbs
+++ b/test/fixtures/themes/110-page-builder/valid/usage-in-partial/partials/header.hbs
@@ -1,0 +1,3 @@
+{{#match @page.show_title_and_feature_image}}
+    <p>Title + Feature image</p>
+{{/match}}

--- a/test/fixtures/themes/110-page-builder/valid/usage-in-template/default.hbs
+++ b/test/fixtures/themes/110-page-builder/valid/usage-in-template/default.hbs
@@ -1,0 +1,14 @@
+<html>
+
+<head>
+    <title>Test Theme</title>
+    <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
+</head>
+
+<body>
+    {{#match @page.show_title_and_feature_image}}
+        <p>Title + Feature image</p>
+    {{/match}}
+</body>
+
+</html>


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3566
refs https://github.com/TryGhost/Ghost/pull/17416

- sets up a new `GS110` set of rules for checking `@page` usage
- `GS110-NO-MISSING-PAGE-BUILDER-USAGE` ensures that all known `@page` properties are used at least once in a theme
  - used to indicate missing feature usage when installing/activating as well as in-situ compatibility warnings in Admin next to the related feature UI
- `GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE` ensures that each `@page` property encountered is a known property
  - used to highlight a potentially incompatible theme when new `@page` properties have been used but the version of `gscan` included with an older version of Ghost isn't aware of them
