### PR TITLE
Precalculated normalized file names to optimize performance

### DIFF
--- a/lib/ast-linter/rules/mark-used-partials.js
+++ b/lib/ast-linter/rules/mark-used-partials.js
@@ -1,5 +1,6 @@
 const Rule = require('./base');
 const {getPartialName} = require('../helpers');
+const {normalizePath} = require('../../utils');
 
 module.exports = class MarkUsedPartials extends Rule {
     _markUsedPartials(node) {
@@ -8,6 +9,7 @@ module.exports = class MarkUsedPartials extends Rule {
         if (nodeName) {
             this.scanner.context.partials.push({
                 node: nodeName,
+                normalizedName: normalizePath(nodeName),
                 type: node.type,
                 loc: node.loc,
                 parameters: node.params ? node.params.map(p => p.original) : null

--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const spec = require('../specs');
 const versions = require('../utils').versions;
 const ASTLinter = require('../ast-linter');
-const {normalizePath} = require('../utils');
 
 function processFileFunction(files, failures, theme, partialsFound) {
     const processedFiles = [];
@@ -61,7 +60,8 @@ function processFileFunction(files, failures, theme, partialsFound) {
         linter.partials.forEach((partial) => {
             const partialName = partial.node;
             partialsFound[partialName] = true;
-            const file = files.find(f => normalizePath(f.file) === `partials/${normalizePath(partialName)}.hbs`);
+
+            const file = files.find(f => f.normalizedFile === `partials/${partial.normalizedName}.hbs`);
             if (file) {
                 // Find all inline partial declaration that were within the partial usage block
                 const childrenInlinePartials = [...parentInlinePartials];

--- a/lib/checks/090-template-syntax.js
+++ b/lib/checks/090-template-syntax.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const {versions, normalizePath, getPackageJSON} = require('../utils');
+const {versions, getPackageJSON} = require('../utils');
 const ASTLinter = require('../ast-linter');
 
 function processFileFunction(files, failures, rules) {
@@ -30,8 +30,8 @@ function processFileFunction(files, failures, rules) {
             });
         }
 
-        linter.partials.forEach(({node: partial}) => {
-            const file = files.find(f => normalizePath(f.file) === `partials/${normalizePath(partial)}.hbs`);
+        linter.partials.forEach(({normalizedName}) => {
+            const file = files.find(f => f.normalizedFile === `partials/${normalizedName}.hbs`);
             if (file) {
                 processFile(linter, file);
             }

--- a/lib/checks/100-custom-template-settings-usage.js
+++ b/lib/checks/100-custom-template-settings-usage.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const {versions, normalizePath} = require('../utils');
+const {versions} = require('../utils');
 const ASTLinter = require('../ast-linter');
 
 function getRules(id, options) {
@@ -103,8 +103,8 @@ function parseWithAST({theme, log, file, rules, callback}){
             callback(linter);
         }
 
-        linter.partials.forEach(({node: partial}) => {
-            const partialFile = theme.files.find(f => normalizePath(f.file) === `partials/${normalizePath(partial)}.hbs`);
+        linter.partials.forEach(({normalizedName}) => {
+            const partialFile = theme.files.find(f => f.normalizedFile === `partials/${normalizedName}.hbs`);
             if (partialFile) {
                 processFile(partialFile);
             }

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const spec = require('../specs');
-const {versions, normalizePath} = require('../utils');
+const {versions} = require('../utils');
 const ASTLinter = require('../ast-linter');
 
 function getRules(id, options) {
@@ -104,8 +104,8 @@ function parseWithAST({theme, log, file, rules, callback}) {
             callback(linter);
         }
 
-        linter.partials.forEach(({node: partial}) => {
-            const partialFile = theme.files.find(f => normalizePath(f.file) === `partials/${normalizePath(partial)}.hbs`);
+        linter.partials.forEach(({normalizedName}) => {
+            const partialFile = theme.files.find(f => f.normalizedFile === `partials/${normalizedName}.hbs`);
             if (partialFile) {
                 processFile(partialFile);
             }

--- a/lib/checks/120-no-unknown-globals.js
+++ b/lib/checks/120-no-unknown-globals.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const spec = require('../specs');
 const versions = require('../utils').versions;
 const ASTLinter = require('../ast-linter');
-const {normalizePath} = require('../utils');
 
 function processFileFunction(files, failures, theme, partialsFound) {
     const processedFiles = [];
@@ -61,7 +60,7 @@ function processFileFunction(files, failures, theme, partialsFound) {
         linter.partials.forEach((partial) => {
             const partialName = partial.node;
             partialsFound[partialName] = true;
-            const file = files.find(f => normalizePath(f.file) === `partials/${normalizePath(partialName)}.hbs`);
+            const file = files.find(f => f.normalizedFile === `partials/${partial.normalizedName}.hbs`);
             if (file) {
                 // Find all inline partial declaration that were within the partial usage block
                 const childrenInlinePartials = [...parentInlinePartials];

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const os = require('os');
 const path = require('path');
 const ASTLinter = require('./ast-linter');
+const {normalizePath} = require('./utils');
 
 const ignore = [
     'node_modules',
@@ -31,6 +32,7 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
     var makeResult = function makeResult(result, subFilePath, ext, symlink) {
         result.push({
             file: subFilePath,
+            normalizedFile: normalizePath(subFilePath),
             ext,
             symlink
         });

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -9,8 +9,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(96);
@@ -49,8 +49,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(33);
@@ -85,8 +85,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(96);
@@ -121,8 +121,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(99);
@@ -157,8 +157,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -302,8 +302,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(117);
@@ -455,8 +455,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -475,8 +475,8 @@ describe('Checker', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
             theme.results.pass.should.be.an.Array().with.lengthOf(109);
@@ -493,7 +493,7 @@ describe('Checker', function () {
     it('should not follow symlinks', function (done) {
         check(themePath('030-assets/symlink2')).then((theme) => {
             theme.should.be.a.ValidThemeObject();
-            theme.files.should.containEql({file: 'assets/mysymlink', ext: undefined, symlink: true});
+            theme.files.should.containEql({file: 'assets/mysymlink', normalizedFile: 'assets/mysymlink', ext: undefined, symlink: true});
             theme.results.fail.should.have.ownProperty('GS030-ASSET-SYM');
 
             done();

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -21,8 +21,8 @@ describe('Read theme', function () {
             theme.should.be.a.ValidThemeObject();
 
             theme.files.should.eql([
-                {file: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', ext: '.md', symlink: false}
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
             done();
         }).catch(done);


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/3

- for themes with many files and partials, the checks can take a very long time to run
- digging into it, it seems that this is due to the `normalizePath` function being executed tens of thousands of times over the same strings
- I tried optimizing the function but it wasn't easy, so the next best step is to precalculate the normalized paths when loading the theme, and then they're ready to go next time
- this optimizes the check time of a particularly heavy theme from 5s to 1.7s on my local machine, and I bet slower machines get a bigger improvement