### PR TITLE
🐛 Addressed the issue where files in the uploads folder couldn't be deleted in case of an error.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,7 +60,10 @@ app.post('/',
             .then(function processResult(theme) {
                 debug('Checked: ' + zip.name);
                 res.theme = theme;
-
+            }).catch(function (error) {
+                debug('Calling next with error');
+                return next(error);
+            }).finally(() => {
                 debug('attempting to remove: ' + req.file.path);
                 fs.remove(req.file.path)
                     .then(function () {
@@ -72,9 +75,6 @@ app.post('/',
                         debug('Calling next');
                         return next();
                     });
-            }).catch(function (error) {
-                debug('Calling next with error');
-                return next(error);
             });
     },
     function doRender(req, res) {


### PR DESCRIPTION
Closes #519

- In the scenario where a user uploaded corrupted files and attempted to scan them using gscan, an error occurred.
- Previously, in this scenario, we failed to delete the uploaded file stored locally under the uploads folder.
- Issue found: The identified bug was that we were only deleting the file when the promise was successfully resolved, and in the case of an error, we were simply moving to the next middleware.
- Issue fixed: To resolve this issue, a finally block has been added to ensure that uploaded files are deleted in any case.