### PR TITLE
Added skipChecks option to check function

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -20,11 +20,12 @@ const labsEnabledHelpers = {
  * @param {string} [options.checkVersion] version to check the theme against
  * @param {string} [options.themeName] name of the checked theme
  * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
+ * @param {boolean} [options.skipChecks] flag to allow reading theme without incurring check costs
  * @returns {Promise<Object>}
  */
 const check = async function checkAll(themePath, options = {}) {
     // Require checks late to avoid loading all until used
-    const checks = requireDir('./checks');
+    const checks = options.skipChecks === true ? [] : requireDir('./checks');
     const passedVersion = _.get(options, 'checkVersion', versions.default);
     let version = passedVersion;
 

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -4,6 +4,22 @@ const {check} = require('../lib/checker');
 process.env.NODE_ENV = 'testing';
 
 describe('Checker', function () {
+    it('can read theme but skip checks', function (done) {
+        check(themePath('is-empty'), {checkVersion: 'canary', skipChecks: true}).then((theme) => {
+            theme.should.be.a.ValidThemeObject();
+
+            theme.files.should.eql([
+                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
+            ]);
+
+            theme.results.pass.should.be.an.Array().with.lengthOf(0);
+            theme.results.fail.should.be.an.Object().with.keys();
+
+            done();
+        }).catch(done);
+    });
+
     it('returns a valid theme when running all checks', function (done) {
         check(themePath('is-empty'), {checkVersion: 'v2'}).then((theme) => {
             theme.should.be.a.ValidThemeObject();


### PR DESCRIPTION
no issue

- in some scenarios we want to read a theme's structure quickly and don't care about running the full suite of checks
- added `skipChecks` option that bypasses the heavier checks
  - does not skip the linter based checks because those are currently coupled with theme reading
