### PR TITLE
Add support for content_api_url and content_api_key helpers

### DIFF
--- a/lib/specs/canary.js
+++ b/lib/specs/canary.js
@@ -15,7 +15,7 @@ const authorHelperDocs = `Find more information about the <code>{{authors}}</cod
 const tierDesc = `Ghost now supports multiple tiers and subscriptions. All product and price related helpers have been reworked to account for this.`;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = ['total_members', 'total_paid_members', 'comment_count', 'comments', 'recommendations', 'readable_url'];
+let knownHelpers = ['total_members', 'total_paid_members', 'comment_count', 'comments', 'recommendations', 'readable_url', 'content_api_url', 'content_api_key'];
 let templates = [];
 let rules = {
     // New rules

--- a/test/fixtures/themes/005-compile/v5/valid/default.hbs
+++ b/test/fixtures/themes/005-compile/v5/valid/default.hbs
@@ -3,10 +3,15 @@
     <title>Test Theme</title>
     <link rel="stylesheet" type="text/css" href="{{asset "css/style.css"}}">
     {{ghost_head}}
+
 </head>
 <body>
 
     <h1>{{@blog.title}}</h1>
+    {{content_api_key}}
+    {{content_api_url absolute=false}}
+    {{content_api_url absolute=true}}
+
     {{ghost_foot}}
 </body>
 </html>


### PR DESCRIPTION
Added these two keys to the list of known helpers for v5.
Added them into a fixture theme for test coverage [for the error that they were triggering] but would welcome suggestions on a better test structure.