### PR TITLE
filter bug ugly hack

### DIFF
--- a/lib/checks/100-custom-template-settings-usage.js
+++ b/lib/checks/100-custom-template-settings-usage.js
@@ -137,8 +137,7 @@ const ruleImplementations = {
             result.customThemeSettings = new Set();
         },
         eachFile: ({file, theme, log, result, partialVerificationCache}) => {
-            let templateTest = file.file.match(/(?<!partials\/.+?)\.hbs$/);
-
+            let templateTest = file.file.match(/\.hbs$/);
             if (templateTest) {
                 parseWithAST({file, theme, rules: {
                     'mark-used-custom-theme-setting': require(`../ast-linter/rules/mark-used-custom-theme-settings`)
@@ -147,7 +146,14 @@ const ruleImplementations = {
                         result.customThemeSettings.add(variable);
                     });
                 }});
-            }
+                let regex = /\{\{[^}]*@custom\.([^\s}]+)[^}]*\}\}/g;
+                let match = file.content.matchAll(regex);
+                if (match) {
+                    for (const m of match) {
+                        result.customThemeSettings.add(m[1]);
+                    }
+                }   
+            } 
         },
         done: ({log, theme, result}) => {
             const config = Object.keys(theme.customSettings);


### PR DESCRIPTION
ref #464 

This is an ugly hack for failure of the parser to recognize custom variables when included in complex filter expression.

There's probably a great way to use the AST parser to do this.  I don't know what it is.

Tests pass.  Will also commit (coming shortly!) a set of tests that cover this use of custom variables.