### PR TITLE
🎨 Show all custom theme setting errors for each file with line number

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -141,7 +141,7 @@ function outputResult(result, options) {
                 ui.log(message);
             });
         } else {
-            ui.log(`${chalk.bold('Affected Files:')} ${_.map(result.failures, 'ref')}`);
+            ui.log(`${chalk.bold('Affected Files:')} ${_.uniq(_.map(result.failures, 'ref')).join(', ')}`);
         }
     }
 

--- a/lib/checks/090-template-syntax.js
+++ b/lib/checks/090-template-syntax.js
@@ -34,9 +34,11 @@ function processFileFunction(files, failures, rules, partialVerificationCache) {
         });
 
         if (astResults.length) {
-            failures.push({
-                ref: themeFile.file,
-                message: astResults[0].message
+            astResults.forEach((result) => {
+                failures.push({
+                    ref: themeFile.file,
+                    message: `${result.message} (L${result.line})`
+                });
             });
         }
 

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -535,7 +535,7 @@ describe('Format', function () {
 
                 theme.results.error.byFiles['assets/my.css'].length.should.eql(3);
                 theme.results.error.byFiles['default.hbs'].length.should.eql(21);
-                theme.results.error.byFiles['post.hbs'].length.should.eql(65);
+                theme.results.error.byFiles['post.hbs'].length.should.eql(66);
                 theme.results.error.byFiles['partials/mypartial.hbs'].length.should.eql(5);
                 theme.results.error.byFiles['index.hbs'].length.should.eql(14);
 


### PR DESCRIPTION
ref https://github.com/TryGhost/gscan/issues/573

- currently when a file has multiple custom theme setting errors, gscan only reports one at a time. This makes it difficult to debug a file if there are multiple errors.
- with this change, all errors for a file will be shown with a line number to make it easy to edit
- using the cli without the verbose tag still shows a comma-delimited list, with each file listed only once

before:
<img width="300" alt="Screenshot 2025-05-03 at 10 42 21 AM" src="https://github.com/user-attachments/assets/1935d4f0-4a10-41d6-8b27-801fbd46aef7" />

after (each file only has two errors, but i did test with 1 and 3):
<img width="300" alt="Screenshot 2025-05-03 at 11 25 27 AM" src="https://github.com/user-attachments/assets/21db9e18-0a55-42fb-bbdd-4ddb2af3e265" />

cli output without `--verbose`:
```
Your theme has 1 error!
----

Errors
------
Important to fix, functionality may be degraded.

- Error: An unknown custom theme setting has been used.
Affected Files: index.hbs, partials/post-card.hbs, page.hbs, post.hbs

```

- The smaller footprint of this PR makes it easier to find and fix bugs in theme files without completely overhauling the checker