### PR TITLE
Updated tryghost/actions to use main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,6 @@ on:
       - 'renovate/*'
 jobs:
   test:
-    uses: tryghost/actions/.github/workflows/test.yml@a7220081e9cc44ca57af80bfe7c03e08a42fb97c
+    uses: tryghost/actions/.github/workflows/test.yml@main
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- This was pinned to an out of date commit
- Other repos like framework use @main https://github.com/TryGhost/framework/blob/main/.github/workflows/test.yml#L10C11-L10C59
- This means they are always up-to-date
- Changing this so the action stays fresh and gscan doesn't fall behind