### PR TITLE
Made Sentry middleware compatible with version 9

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,8 @@
+// Init Sentry middleware
+require('./middlewares/sentry');
+const sentry = require('@sentry/node');
+
+// Require rest of the modules
 const express = require('express');
 const debug = require('@tryghost/debug')('app');
 const hbs = require('express-hbs');
@@ -9,15 +14,12 @@ const gscan = require('../lib');
 const fs = require('fs-extra');
 const logRequest = require('./middlewares/log-request');
 const uploadValidation = require('./middlewares/upload-validation');
-const sentry = require('./middlewares/sentry');
 const ghostVer = require('./ghost-version');
 const pkgJson = require('../package.json');
 const ghostVersions = require('../lib/utils').versions;
 const upload = multer({dest: __dirname + '/uploads/'});
 const app = express();
 const scanHbs = hbs.create();
-
-app.use(sentry.requestHandler);
 
 // Configure express
 app.set('x-powered-by', false);
@@ -89,8 +91,6 @@ app.post('/',
     }
 );
 
-app.use(sentry.errorHandler);
-
 app.use(function (req, res, next) {
     next(new errors.NotFoundError({message: 'Page not found'}));
 });
@@ -109,5 +109,7 @@ app.use(function (err, req, res, next) {
 
     res.render(template, {message: err.message, stack: err.stack, details: err.errorDetails, context: err.context});
 });
+
+sentry.setupExpressErrorHandler(app);
 
 server.start(app, config.get('port'));

--- a/app/middlewares/sentry.js
+++ b/app/middlewares/sentry.js
@@ -1,9 +1,5 @@
 const sentryDSN = process.env.SENTRY_DSN;
 
-const expressNoop = function (req, res, next) {
-    next();
-};
-
 if (sentryDSN) {
     const Sentry = require('@sentry/node');
     const version = require('../../package.json').version;
@@ -12,14 +8,4 @@ if (sentryDSN) {
         release: 'gscan@' + version,
         environment: process.env.NODE_ENV
     });
-
-    module.exports = {
-        requestHandler: Sentry.Handlers.requestHandler(),
-        errorHandler: Sentry.Handlers.errorHandler()
-    };
-} else {
-    module.exports = {
-        requestHandler: expressNoop,
-        errorHandler: expressNoop
-    };
 }


### PR DESCRIPTION
- Sentry.Handlers.requestHandler() and Sentry.Handlers.errorHandler() are no longer available
- Initializing and importing Sentry should be enough from now on