### PR TITLE
add split helper to gscan

### DIFF
--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -8,7 +8,7 @@ const previousTemplates = previousSpec.templates;
 const previousRules = previousSpec.rules;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = [];
+let knownHelpers = ['split'];
 let templates = [];
 let rules = {
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': {


### PR DESCRIPTION
Companion PR to https://github.com/TryGhost/Ghost/pull/25194 

Adds 'split' as a valid helper.