### PR TITLE
Added --ignore-scripts flag to yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ COPY package.json yarn.lock ./
 # ---- Dependencies ----
 FROM base AS dependencies
 # Install production dependencies
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --ignore-scripts --production --frozen-lockfile
 # Copy only the production node_modules for later use
 RUN cp -R node_modules prod_node_modules
 
 # Install all dependencies, including 'devDependencies'
-RUN yarn install --frozen-lockfile
+RUN yarn install --ignore-scripts --frozen-lockfile
 
 # ---- Release ----
 FROM node:22.13.1-alpine3.21 AS release


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- there have been multiple recent npm incidents with compromised packages using pre/post-install scripts to run malicious scripts
- we want to default to not running these scripts as a security precaution, this matches behaviour of pnpm which is touted as a modern, more secure, npm package manager