### PR TITLE
Fixed link to get helper for limit all warnings

### DIFF
--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -15,7 +15,7 @@ let rules = {
         level: 'warning',
         rule: 'Using <code>limit="all"</code> in <code>{{#get}}</code> helper is not supported',
         details: oneLineTrim`In Ghost 6.0 and later, <code>limit="all"</code> will return at most 100 results. Consider using a specific limit number or implementing pagination instead.<br>
-        Find more information about the <code>{{#get}}</code> helper <a href="${docsBaseUrl}helpers/get/" target=_blank>here</a>.`,
+        Find more information about the <code>{{#get}}</code> helper <a href="${docsBaseUrl}helpers/functional/get/" target=_blank>here</a>.`,
         helper: '{{#get}}'
     },
     'GS090-NO-LIMIT-OVER-100-IN-GET-HELPER': {
@@ -23,7 +23,7 @@ let rules = {
         rule: 'Using <code>limit</code> values greater than 100 in <code>{{#get}}</code> helper is not supported',
         details: oneLineTrim`Ghost automatically caps <code>limit</code> values at 100, so using higher values will not return more results.
         Consider using pagination or setting the limit to 100 or lower.<br>
-        Find more information about the <code>{{#get}}</code> helper <a href="${docsBaseUrl}helpers/get/" target=_blank>here</a>.`,
+        Find more information about the <code>{{#get}}</code> helper <a href="${docsBaseUrl}helpers/functional/get/" target=_blank>here</a>.`,
         helper: '{{#get}}'
     },
     'GS001-DEPR-TWITTER-URL': {


### PR DESCRIPTION
no ref

- Warnings for using limit="all" in a get helper were linking to the wrong place
- They now correctly go to https://docs.ghost.org/themes/helpers/functional/get