### PR TITLE
Fixed the Check Links job, updated some links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: lts/*
+          node-version: 22 # TODO: return to lts/* once 1) we're back to passing runs and 2) 24 is added to package.json
           cache: yarn
 
       - run: yarn

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -323,7 +323,7 @@ rules = {
         rule: 'Replace <code>{{@blog.posts_per_page}}</code> with <code>{{@config.posts_per_page}}</code>',
         details: oneLineTrim`The global <code>{{@blog.posts_per_page}}</code> property was replaced with <code>{{@config.posts_per_page}}</code>.<br>
         Read <a href="${docsBaseUrl}helpers/config/" target=_blank>here</a> about the attribute and
-        check <a href="${docsBaseUrl}structure/#packagejson" target=_blank>here</a> where you can customise the posts per page setting, as this is now adjustable in your theme.`,
+        check <a href="${docsBaseUrl}structure/#package-json" target=_blank>here</a> where you can customise the posts per page setting, as this is now adjustable in your theme.`,
         regex: /{{\s*?@blog\.posts_per_page\s*?}}/g,
         helper: '{{@blog.posts_per_page}}'
     },
@@ -394,65 +394,64 @@ rules = {
         level: 'error',
         rule: '<code>package.json</code> file should be present',
         details: oneLineTrim`You should provide a <code>package.json</code> file for your theme.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
     },
     'GS010-PJ-PARSE': {
         level: 'error',
         rule: '<code>package.json</code> file can be parsed',
         details: oneLineTrim`Your <code>package.json</code> file couldn't be parsed. This is mostly caused by a missing or unnecessary <code>','</code> or the wrong usage of <code>'""'</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.<br>
-        A good reference for your <code>package.json</code> file is always the latest version of  <a href="https://github.com/TryGhost/Casper/blob/master/package.json" target=_blank>Casper</a>.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-NAME-LC': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"name"</code> must be lowercase',
         details: oneLineTrim`The property <code>"name"</code> in your <code>package.json</code> file must be lowercase.<br>
         Good examples are: <code>"my-theme"</code> or <code>"theme"</code> rather than <code>"My Theme"</code> or <code>"Theme"</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-NAME-HY': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"name"</code> must be hyphenated',
         details: oneLineTrim`The property <code>"name"</code> in your <code>package.json</code> file must be hyphenated.<br>
         Please use <code>"my-theme"</code> rather than <code>"My Theme"</code> or <code>"my theme"</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-NAME-REQ': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"name"</code> is required',
         details: oneLineTrim`Please add the property <code>"name"</code> to your <code>package.json</code>. E.g. <code>{"name": "my-theme"}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
     },
     'GS010-PJ-VERSION-SEM': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"version"</code> must be semver compliant',
         details: oneLineTrim`The property <code>"version"</code> in your <code>package.json</code> file must be semver compliant. E.g. <code>{"version": "1.0.0"}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-VERSION-REQ': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"version"</code> is required',
         details: oneLineTrim`Please add the property <code>"version"</code> to your <code>package.json</code>. E.g. <code>{"version": "1.0.0"}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
     },
     'GS010-PJ-AUT-EM-VAL': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"author.email"</code> must be valid',
         details: oneLineTrim`The property <code>"author.email"</code> in your <code>package.json</code> file must a valid email. E.g. <code>{"author": {"email": "hello@example.com"}}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CONF-PPP': {
         level: 'recommendation',
         rule: '<code>package.json</code> property <code>"config.posts_per_page"</code> is recommended. Otherwise, it falls back to 5',
         details: oneLineTrim`Please add <code>"posts_per_page"</code> to your <code>package.json</code>. E.g. <code>{"config": { "posts_per_page": 5}}</code>.<br>
         If no <code>"posts_per_page"</code> property is provided, Ghost will use its default setting of 5 posts per page.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CONF-PPP-INT': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"config.posts_per_page"</code> must be a number above 0',
         details: oneLineTrim`The property <code>"config.posts_per_page"</code> in your <code>package.json</code> file must be a number greater than zero. E.g. <code>{"config": { "posts_per_page": 5}}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-AUT-EM-REQ': {
         level: 'error',
@@ -461,7 +460,7 @@ rules = {
         The email is required so that themes which are distributed (either free or paid) have a method of contacting the author so users can get support and more importantly so that>
         Ghost can reach out about breaking changes and security updates.<br>
         The <code>package.json</code> file is <strong>NOT</strong> accessible when uploaded to a blog so if the theme is only uploaded to a single blog, no one will see this email address.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> to see which properties are required and which are recommended.`
     },
     'GS020-INDEX-REQ': {
         level: 'error',
@@ -476,14 +475,14 @@ rules = {
         rule: 'A template file called <code>post.hbs</code> must be present',
         fatal: true,
         details: oneLineTrim`Your theme must have a template file called <code>index.hbs</code>.<br>
-        Read <a href="${docsBaseUrl}structure/#templates" target=_blank>here</a> more about the required template structure and <code>post.hbs</code> in <a href="${docsBaseUrl}structure/#posthbs" target=_blank>particular</a>.`,
+        Read <a href="${docsBaseUrl}structure/#templates" target=_blank>here</a> more about the required template structure and <code>post.hbs</code> in <a href="${docsBaseUrl}structure/#post-hbs" target=_blank>particular</a>.`,
         path: 'post.hbs'
     },
     'GS020-DEF-REC': {
         level: 'recommendation',
         rule: 'Provide a default layout template called default.hbs',
         details: oneLineTrim`It is recommended that your theme has a template file called <code>default.hbs</code>.<br>
-        Read <a href="${docsBaseUrl}structure/#templates" target=_blank>here</a> more about the recommended template structure and <code>default.hbs</code> in <a href="${docsBaseUrl}structure/#defaulthbs" target=_blank>particular</a>.`,
+        Read <a href="${docsBaseUrl}structure/#templates" target=_blank>here</a> more about the recommended template structure and <code>default.hbs</code> in <a href="${docsBaseUrl}structure/#default-hbs" target=_blank>particular</a>.`,
         path: 'default.hbs'
     },
     'GS030-ASSET-REQ': {

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -405,7 +405,7 @@ let rules = {
         rule: '<code>{{@blog.permalinks}}</code> was removed',
         details: oneLineTrim`With the introduction of Dynamic Routing, you can define multiple permalinks.<br>
         The <code>{{@blog.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.
-        Find more information about Ghost data helpers <a href="${docsBaseUrl}/helpers/#data-helpers" target=_blank>here</a>.`,
+        Find more information about Ghost data helpers <a href="${docsBaseUrl}helpers/data/" target=_blank>here</a>.`,
         regex: /{{\s*?@blog\.permalinks\s*?}}/g,
         helper: '{{@blog.permalinks}}'
     },
@@ -843,7 +843,7 @@ let rules = {
         level: 'warning',
         rule: '<code>package.json</code> property <code>keywords</code> should contain <code>ghost-theme</code>',
         details: oneLineTrim`The property <code>keywords</code> in your <code>package.json</code> file must contain <code>ghost-theme</code>. E.g. <code>{"keywords": ["ghost-theme"]}</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     }
 };
 

--- a/lib/specs/v3.js
+++ b/lib/specs/v3.js
@@ -22,21 +22,21 @@ let rules = {
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is recommended. Otherwise, it falls back to "v3"',
         details: oneLineTrim`Please add <code>"ghost-api"</code> to your <code>package.json</code>. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>
         If no <code>"ghost-api"</code> property is provided, Ghost will use its default setting of "v3" Ghost API.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-GHOST-API-V01': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is incompatible with current version of Ghost API and will fall back to "v3"',
         details: oneLineTrim`Please change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v3"}}</code>.<br>
         If <code>"ghost-api"</code> property is left at "v0.1", Ghost will use its default setting of "v3".<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS001-DEPR-ESC': {
         level: 'error',
         rule: 'Replace <code>{{error.code}}</code> with <code>{{error.statusCode}}</code>',
         details: oneLineTrim`The usage of <code>{{error.code}}</code> is deprecated and should be replaced with <code>{{error.statusCode}}</code>.<br>
         When in <code>error</code> context, e. g. in the <code>error.hbs</code> template, replace <code>{{code}}</code> with <code>{{statusCode}}</code>.<br>
-        Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}structure/#errorhbs" target=_blank>here</a>.`,
+        Find more information about the <code>error.hbs</code> template <a href="${docsBaseUrl}structure/#error-hbs" target=_blank>here</a>.`,
         regex: /{{\s*?(?:error\.)?(code)\s*?}}/g,
         helper: '{{error.code}}'
     },

--- a/lib/specs/v4.js
+++ b/lib/specs/v4.js
@@ -35,75 +35,75 @@ let rules = {
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is deprecated.',
         details: oneLineTrim`Remove <code>"ghost-api"</code> from your <code>package.json</code>.<br>
         The <code>ghost-api</code> support will be removed in next major version of Ghost and should not be used.
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-GHOST-API-V01': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is incompatible with current version of Ghost API and will fall back to "v4"',
         details: oneLineTrim`Change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v4"}}</code>.<br>
         If <code>"ghost-api"</code> property is left at "v0.1", Ghost will use its default setting of "v4".<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-GHOST-API-V2': {
         level: 'warning',
         rule: '<code>package.json</code> property <code>"engines.ghost-api"</code> is using a deprecated version of Ghost API',
         details: oneLineTrim`Change <code>"ghost-api"</code> in your <code>package.json</code> to higher version. E.g. <code>{"engines": {"ghost-api": "v4"}}</code>.<br>
         If <code>"ghost-api"</code> property is left at "v2", it will stop working with next major version upgrade and default to v5.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-TOTAL-SETTINGS': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"config.custom"</code> contains too many settings',
         details: oneLineTrim`Remove key from <code>"config.custom"</code> in your <code>package.json</code> to have less than or exactly 20 settings.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-CASE': {
         level: 'error',
         rule: '<code>package.json</code> property <code>"config.custom"</code> contains a property that isn\'t snake-cased',
         details: oneLineTrim`Rewrite all property in <code>"config.custom"</code> in your <code>package.json</code> in snake case.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-TYPE': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> should have a known <code>"type"</code>.',
         details: oneLineTrim`Only use the following types: <code>"select"</code>, <code>"boolean"</code>, <code>"color"</code>, <code>"image"</code>, <code>"text"</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-GROUP': {
         level: 'recommendation',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> should have a known <code>"group"</code>.',
         details: oneLineTrim`Only use the following groups: <code>"post"</code>, <code>"homepage"</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-SELECT-OPTIONS': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> of type <code>"select"</code> need to have at least 2 <code>"options"</code>.',
         details: oneLineTrim`Make sure there is at least 2 <code>"options"</code> in each <code>"select"</code> custom theme property.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-SELECT-DEFAULT': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> of type <code>"select"</code> need to have a valid <code>"default"</code>.',
         details: oneLineTrim`Make sure the <code>"default"</code> property matches a value in <code>"options"</code> of the same <code>"select"</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-BOOLEAN-DEFAULT': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> of type <code>"boolean"</code> need to have a valid <code>"default"</code>.',
         details: oneLineTrim`Make sure the <code>"default"</code> property is either <code>true</code> or <code>false</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-COLOR-DEFAULT': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> of type <code>"color"</code> need to have a valid <code>"default"</code>.',
         details: oneLineTrim`Make sure the <code>"default"</code> property is a valid 6-hexadecimal-digit color code like <code>#15171a</code>.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS010-PJ-CUST-THEME-SETTINGS-IMAGE-DEFAULT': {
         level: 'error',
         rule: '<code>package.json</code> objects defined in <code>"config.custom"</code> of type <code>"image"</code> can\'t have a <code>"default"</code> value.',
         details: oneLineTrim`Make sure the <code>"default"</code> property is either <code>null</code>, an empty string <code>''</code> or isn't present.<br>
-        Check the <a href="${docsBaseUrl}structure/#packagejson" target=_blank><code>package.json</code> documentation</a> for further information.`
+        Check the <a href="${docsBaseUrl}structure/#package-json" target=_blank><code>package.json</code> documentation</a> for further information.`
     },
     'GS001-DEPR-LABS-MEMBERS': {
         level: 'warning',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -23,7 +23,7 @@ let rules = {
         level: 'warning',
         rule: 'Remove <code>"engines.ghost-api"</code> from <code>package.json</code>',
         details: oneLineTrim`The <code>"ghost-api"</code> version is no longer used and can be removed.<br>
-        Find more information about the <code>package.json</code> file <a href="${docsBaseUrl}structure/#packagejson" target=_blank>here</a>.`
+        Find more information about the <code>package.json</code> file <a href="${docsBaseUrl}structure/#package-json" target=_blank>here</a>.`
     },
     'GS010-PJ-GHOST-CARD-ASSETS-NOT-PRESENT': {
         level: 'warning',
@@ -650,7 +650,7 @@ let rules = {
         rule: 'Remove uses of <code>{{@blog.permalinks}}</code>',
         details: oneLineTrim`With the introduction of Dynamic Routing, you can define multiple permalinks.<br>
         The <code>{{@blog.permalinks}}</code> property will therefore no longer be used and should be removed from the theme.
-        Find more information about Ghost data helpers <a href="${docsBaseUrl}/helpers/#data-helpers" target=_blank>here</a>.`,
+        Find more information about Ghost data helpers <a href="${docsBaseUrl}helpers/data/" target=_blank>here</a>.`,
         regex: /{{\s*?@blog\.permalinks\s*?}}/g,
         helper: '{{@blog.permalinks}}'
     },


### PR DESCRIPTION
no ref

- In reviewing some renovate PRs for updating Node versions, I noticed our check links job was failing because it was trying to use Node 24. This is because the workflow is set up to use `lts/*`, which is 24, but that's not a permitted version in our `package.json`
- I'm going to update everything in steps just to make sure nothing gets missed, so the first step is to get check links passing by setting the Node version to 22.
- In doing so I found some broken links, so this PR fixes them
- Future PRs like https://github.com/TryGhost/gscan/pull/632 will update Node to 24, at which point I plan to update check-links.yml as well