### PR TITLE
Upgrade glob to v13

### DIFF
--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -1,26 +1,28 @@
 const debug = require('@tryghost/debug')('zip');
 const path = require('path');
 const os = require('os');
-const glob = require('glob');
+const {glob} = require('glob');
 const {extract} = require('@tryghost/zip');
 const errors = require('@tryghost/errors');
 const uuid = require('uuid');
 const _ = require('lodash');
 
-const resolveBaseDir = (zipPath) => {
-    return new Promise((resolve) => {
-        glob('**/index.hbs', {cwd: zipPath, nosort: true}, function (err, matches) {
-            var matchedPath;
+const resolveBaseDir = async (zipPath) => {
+    let matches = [];
 
-            if (!err && !_.isEmpty(matches)) {
-                debug('Found matches', matches);
-                matchedPath = matches[0].replace(/index\.hbs$/, '');
-                zipPath = path.join(zipPath, matchedPath).replace(/\/$/, '');
-            }
+    try {
+        matches = await glob('**/index.hbs', {cwd: zipPath, nosort: true});
+    } catch (err) {
+        debug('Glob match error while resolving zip base dir', err);
+    }
 
-            return resolve(zipPath);
-        });
-    });
+    if (!_.isEmpty(matches)) {
+        debug('Found matches', matches);
+        const matchedPath = matches[0].replace(/index\.hbs$/, '');
+        zipPath = path.join(zipPath, matchedPath).replace(/\/$/, '');
+    }
+
+    return zipPath;
 };
 
 const readZip = (zip) => {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express": "5.2.1",
     "express-hbs": "^2.4.2",
     "fs-extra": "^11.1.1",
-    "glob": "^8.1.0",
+    "glob": "^13.0.6",
     "lodash": "^4.17.21",
     "multer": "^2.0.0",
     "pluralize": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3658,6 +3658,15 @@ glob@^10.0.0, glob@^10.4.1, glob@^10.4.2, glob@^10.4.5:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
+glob@^13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
+  dependencies:
+    minimatch "^10.2.2"
+    minipass "^7.1.3"
+    path-scurry "^2.0.2"
+
 glob@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
@@ -3680,17 +3689,6 @@ glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
 
 globals@^12.1.0:
   version "12.4.0"
@@ -4247,6 +4245,11 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lru-cache@^11.0.0:
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.6.tgz#356bf8a29e88a7a2945507b31f6429a65a192c58"
+  integrity sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -4327,7 +4330,7 @@ minimatch@9.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^10.2.1:
+minimatch@^10.2.1, minimatch@^10.2.2:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
   integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
@@ -4341,7 +4344,7 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
+minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -4364,6 +4367,11 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+minipass@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mkdirp@^0.5.1, mkdirp@^0.5.6, mkdirp@~0.5.1:
   version "0.5.6"
@@ -4690,6 +4698,14 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-to-regexp@^8.0.0:
   version "8.3.0"


### PR DESCRIPTION
## Summary
- upgrade `glob` from `^8.1.0` to `^13.0.6`
- update `/Users/john/Sites/gscan/lib/read-zip.js` to use `glob` v13 async API (`{glob}` + `await glob(...)`)
- preserve prior behavior when globbing fails while resolving the extracted zip base directory

## Validation
- `yarn test`
- `yarn lint` (via `posttest`)

## Result
- 337 tests passing
- coverage thresholds still met (branches >= 95%)
