### PR TITLE
Ensure uploaded zip is always removed after scan attempt

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -58,25 +58,29 @@ app.post('/',
         debug('Uploaded: ' + zip.name + ' to ' + zip.path);
         debug('Version to check: ' + options.checkVersion);
 
+        let checkError;
+
         gscan.checkZip(zip, options)
             .then(function processResult(theme) {
                 debug('Checked: ' + zip.name);
                 res.theme = theme;
-
+            }).catch(function (error) {
+                checkError = error;
+            }).finally(function () {
                 debug('attempting to remove: ' + req.file.path);
                 fs.remove(req.file.path)
-                    .then(function () {
-                        debug('Calling next');
-                        return next();
+                    .catch(function (removeError) {
+                        debug('failed to remove uploaded file', removeError);
                     })
-                    .catch(function () {
-                        // NOTE: transform to `.finally(...) once package is compatible with node >=10
+                    .then(function () {
+                        if (checkError) {
+                            debug('Calling next with error');
+                            return next(checkError);
+                        }
+
                         debug('Calling next');
                         return next();
                     });
-            }).catch(function (error) {
-                debug('Calling next with error');
-                return next(error);
             });
     },
     function doRender(req, res) {


### PR DESCRIPTION
Closes #519
Closes #521

## Summary
- fix upload middleware cleanup flow so temporary uploaded files are removed even when `gscan.checkZip(...)` fails
- preserve the original scan error while still attempting cleanup
- ensure `next(...)` is called exactly once in all paths

## Details
- store scan failure in `checkError`
- always run `fs.remove(req.file.path)` in `.finally(...)`
- if cleanup fails, log and continue (do not mask scan result)
- call `next(checkError)` on scan failure, otherwise call `next()`

## Validation
- `yarn test` (includes posttest lint)
- result: 337 passing, coverage thresholds met
