### PR TITLE
Ensure zip extraction cleanup runs on success and failure

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -90,18 +90,12 @@ const checkZip = async function checkZip(path, options) {
         zip = _.clone(path);
     }
 
+    let extractedZipPath;
+
     try {
         const readZip = require('./read-zip');
-        const {path: extractedZipPath} = await readZip(zip);
-        const theme = await check(extractedZipPath, Object.assign({themeName: zip.name}, options));
-
-        if (options.keepExtractedDir) {
-            return theme;
-        } else {
-            const fs = require('fs-extra');
-            await fs.remove(zip.origPath);
-            return theme;
-        }
+        ({path: extractedZipPath} = await readZip(zip));
+        return await check(extractedZipPath, Object.assign({themeName: zip.name}, options));
     } catch (error) {
         if (!errors.utils.isGhostError(error)) {
             throw new errors.ValidationError({
@@ -114,6 +108,11 @@ const checkZip = async function checkZip(path, options) {
         }
 
         throw error;
+    } finally {
+        if (!options.keepExtractedDir && zip.origPath) {
+            const fs = require('fs-extra');
+            await fs.remove(zip.origPath);
+        }
     }
 };
 

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -83,6 +83,56 @@ describe('Check zip', function () {
             extractedThemePathExists.should.eql(false);
         });
 
+        it('removes extracted directory when checks fail', async function () {
+            const readThemePath = require.resolve('../lib/read-theme');
+            const originalReadTheme = require(readThemePath);
+            const removeSpy = sinon.spy(fs, 'remove');
+
+            require.cache[readThemePath].exports = async function () {
+                throw new Error('forced check failure');
+            };
+
+            try {
+                await checkZip(themePath('030-assets/ignored.zip'), {checkVersion: 'v1'});
+                should.fail(checkZip, 'Should have errored');
+            } catch (err) {
+                should.exist(err);
+                should.equal(err.errorType, 'ValidationError');
+                should.equal(err.message, 'Failed theme files check');
+            } finally {
+                require.cache[readThemePath].exports = originalReadTheme;
+                removeSpy.restore();
+            }
+
+            removeSpy.calledOnce.should.eql(true);
+            const removedPath = removeSpy.firstCall.args[0];
+            should.exist(removedPath);
+
+            const extractedThemePathExists = await fs.pathExists(removedPath);
+            extractedThemePathExists.should.eql(false);
+        });
+
+        it('removes entire temp directory for nested zips', async function () {
+            const theme = await checkZip(themePath('example.zip'), {checkVersion: 'v1'});
+
+            theme.files.length.should.be.above(0);
+
+            const extractedParentPathExists = await fs.pathExists(path.dirname(theme.path));
+            extractedParentPathExists.should.eql(false);
+        });
+
+        it('keeps extracted directory when keepExtractedDir is true', async function () {
+            const theme = await checkZip(themePath('030-assets/ignored.zip'), {keepExtractedDir: true, checkVersion: 'v1'});
+
+            theme.files.length.should.eql(1);
+            theme.files[0].file.should.match(/default\.hbs/);
+
+            const extractedThemePathExists = await fs.pathExists(theme.path);
+            extractedThemePathExists.should.eql(true);
+
+            await fs.remove(theme.path);
+        });
+
         it('accepts an object zip input', async function () {
             const theme = await checkZip({
                 path: themePath('030-assets/ignored.zip'),
@@ -91,6 +141,8 @@ describe('Check zip', function () {
 
             theme.files.length.should.eql(1);
             theme.files[0].file.should.match(/default\.hbs/);
+
+            await fs.remove(theme.path);
         });
     });
 });


### PR DESCRIPTION
## What
- move `checkZip` cleanup into a `finally` block so extracted temp directories are removed on both success and failure
- preserve `keepExtractedDir: true` behavior
- add regression tests for failure-path cleanup, nested zip cleanup, and keep behavior

## Validation
- `NODE_ENV=testing node node_modules/mocha/bin/mocha -- $(find test -name '*.test.js')`

Closes #657
