### PR TITLE
Use crypto.randomUUID and remove uuid

### DIFF
--- a/app/middlewares/log-request.js
+++ b/app/middlewares/log-request.js
@@ -1,4 +1,4 @@
-var uuid = require('uuid'),
+var randomUUID = require('crypto').randomUUID,
     logging = require('@tryghost/logging');
 
 /**
@@ -7,7 +7,7 @@ var uuid = require('uuid'),
  */
 module.exports = function logRequest(req, res, next) {
     var startTime = Date.now(),
-        requestId = uuid.v1();
+        requestId = randomUUID();
 
     function logResponse() {
         res.responseTime = (Date.now() - startTime) + 'ms';

--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -1,10 +1,10 @@
 const debug = require('@tryghost/debug')('zip');
 const path = require('path');
 const os = require('os');
+const {randomUUID} = require('crypto');
 const {glob} = require('glob');
 const {extract} = require('@tryghost/zip');
 const errors = require('@tryghost/errors');
-const uuid = require('uuid');
 const _ = require('lodash');
 
 const resolveBaseDir = async (zipPath) => {
@@ -26,7 +26,7 @@ const resolveBaseDir = async (zipPath) => {
 };
 
 const readZip = (zip) => {
-    const tempUuid = uuid.v4();
+    const tempUuid = randomUUID();
     const tempPath = os.tmpdir() + '/' + tempUuid;
 
     debug('Reading Zip', zip.path, 'into', tempPath);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "pluralize": "8.0.0",
     "require-dir": "1.2.0",
     "semver": "7.7.4",
-    "uuid": "13.0.0",
     "validator": "^13.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,7 +5819,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@13.0.0, uuid@^13.0.0:
+uuid@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
   integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==


### PR DESCRIPTION
## What this changes
- Replaces `uuid.v4()` and `uuid.v1()` usage with `crypto.randomUUID()`
- Removes the `uuid` dependency

## Why
The project targets Node 20+, so native UUID generation is available and removes external package maintenance overhead.

## Validation
- Ran `yarn test` (includes coverage + posttest lint)
- Result: passing
