### PR TITLE
chore: updated docs link in gscan app

### DIFF
--- a/app/tpl/layouts/default.hbs
+++ b/app/tpl/layouts/default.hbs
@@ -57,7 +57,7 @@
 
         </div>
         <div class="gh-navbar-right">
-            <a class="gh-navbar-item" href="https://ghost.org/docs/themes/" target="blank" rel="noopener">Theme Docs</a>
+            <a class="gh-navbar-item" href="https://docs.ghost.org/themes/" target="blank" rel="noopener">Theme Docs</a>
             <a class="gh-navbar-btn gh-btn" href="https://ghost.org/"><span>Ghost.org</span></a>
         </div>
     </nav>
@@ -99,7 +99,7 @@
     </nav>
     <div class="gh-mobilemenu">
         <a class="gh-navbar-item" href="https://gscan.ghost.org">GScan</a>
-        <a class="gh-navbar-item" href="https://ghost.org/docs/themes/">Theme Docs</a>
+        <a class="gh-navbar-item" href="https://docs.ghost.org/themes/">Theme Docs</a>
         <a class="gh-navbar-item" href="https://ghost.org/">Ghost.org</a>
     </div>
 </header>


### PR DESCRIPTION
no ref

- updates the theme docs links in the web ui for gscan to go to the new docs url

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple static template link update with no logic, data, or security-impacting changes.
> 
> **Overview**
> Updates the GScan layout (`default.hbs`) to point the **Theme Docs** navbar links (desktop and mobile) from `ghost.org/docs/themes/` to the new `docs.ghost.org/themes/` URL.
> 
> Also adds a trailing newline at EOF.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37891d71f831549e085b5532fdc6e843759d5fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->