### PR TITLE
🐛 Fixed chalk imports

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,7 @@ process.removeAllListeners('warning');
 const prettyCLI = require('@tryghost/pretty-cli');
 const ui = require('@tryghost/pretty-cli').ui;
 const _ = require('lodash');
-const chalk = require('chalk');
+const {default: chalk} = require('chalk');
 const gscan = require('../lib');
 const ghostVersions = require('../lib/utils').versions;
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "engines": {
-    "node": "^20.11.1 || ^22.13.1 || ^24.0.0"
+    "node": "^20.19.0 || ^22.13.1 || ^24.0.0"
   },
   "bugs": {
     "url": "https://github.com/TryGhost/gscan/issues"

--- a/test/valid-doc-links.js
+++ b/test/valid-doc-links.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 const path = require('path');
 const glob = require('glob');
-const chalk = require('chalk');
+const {default: chalk} = require('chalk');
 
 const checkIds = process.env.GSCAN_DOC_CHECK_IDS !== 'false';
 


### PR DESCRIPTION
closes https://github.com/TryGhost/gscan/issues/710

- as of chalk v5 `require()` is no longer supported
- this fixes that in the two places we use chalk in gscan, following the pattern in [@tryghost/pretty-cli](https://github.com/TryGhost/framework/blob/main/packages/pretty-cli/lib/styles.js)
- confirmed the cli is working again by running `node bin/cli.js test/fixtures/themes/is-empty`. we should also have tests for the cli to catch stuff like this, will add a follow up issue.
- also bumps the minimum supported Node version to `^20.19.0`. `20.11.1` through at least `20.18.0` weren't working anyway because of other dependency updates (at least `chalk` in `@tryghost/pretty-cli`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small compatibility fix plus a minor Node engine version bump; minimal behavioral change outside module loading.
> 
> **Overview**
> Fixes `chalk` usage under Chalk v5 by switching CommonJS imports to destructure the `default` export (`{default: chalk}`) in the CLI (`bin/cli.js`) and the doc-link validation test (`test/valid-doc-links.js`).
> 
> Also bumps the minimum supported Node 20 engine version in `package.json` from `^20.11.1` to `^20.19.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8739c2b9895277e58385c0b58d72d72824c4eda7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->