### PR TITLE
Fixed linting warnings for variable declarations

### DIFF
--- a/app/middlewares/log-request.js
+++ b/app/middlewares/log-request.js
@@ -1,13 +1,13 @@
-var randomUUID = require('crypto').randomUUID,
-    logging = require('@tryghost/logging');
+const randomUUID = require('crypto').randomUUID;
+const logging = require('@tryghost/logging');
 
 /**
  * @TODO:
  * - move middleware to ignition?
  */
 module.exports = function logRequest(req, res, next) {
-    var startTime = Date.now(),
-        requestId = randomUUID();
+    const startTime = Date.now();
+    const requestId = randomUUID();
 
     function logResponse() {
         res.responseTime = (Date.now() - startTime) + 'ms';

--- a/lib/ast-linter/helpers/index.js
+++ b/lib/ast-linter/helpers/index.js
@@ -49,8 +49,8 @@ function blockParamIndex(name, options) {
         depth < len;
         depth++
     ) {
-        let blockParams = options.blockParams[depth],
-            param = blockParams && blockParams.indexOf(name);
+        const blockParams = options.blockParams[depth];
+        const param = blockParams && blockParams.indexOf(name);
         if (blockParams && param >= 0) {
             return [depth, param];
         }

--- a/lib/checks/002-comment-id.js
+++ b/lib/checks/002-comment-id.js
@@ -16,7 +16,7 @@ const checkCommentID = function checkCommentID(theme, options) {
     });
     _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
-            var template = themeFile.file.match(/\.hbs$/);
+            const template = themeFile.file.match(/\.hbs$/);
 
             if (template) {
                 if (themeFile.content.match(check.regex)) {

--- a/lib/checks/080-helper-usage.js
+++ b/lib/checks/080-helper-usage.js
@@ -17,7 +17,7 @@ module.exports = function checkUsage(theme, options) {
     });
     _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
-            var template = themeFile.file.match(/\.hbs$/);
+            const template = themeFile.file.match(/\.hbs$/);
             const validApi = check.validInAPI ? check.validInAPI.includes(targetApiVersion) : true;
             if (template) {
                 if (validApi && themeFile.content.match(check.regex)) {

--- a/lib/faker/index.js
+++ b/lib/faker/index.js
@@ -1,5 +1,5 @@
-var fakeData = function fakeData(themeFile) {
-    var tag = {
+const fakeData = function fakeData(themeFile) {
+    const tag = {
         id: '345678901',
         name: 'hill',
         description: 'tag for hill',
@@ -9,7 +9,7 @@ var fakeData = function fakeData(themeFile) {
         url: 'http://talltalesofhighhills.com/tag/hill'
     };
 
-    var author = {
+    const author = {
         id: '234567890',
         name: 'John McHill',
         slug: 'john-mchill',
@@ -23,7 +23,7 @@ var fakeData = function fakeData(themeFile) {
         url: 'http:///talltalesofhighhills.com/author/john-mchill'
     };
 
-    var post = {
+    const post = {
         id: '123456789',
         title: 'The highs and lows of hills',
         slug: 'the-highs-and-low-of-hills',
@@ -43,7 +43,7 @@ var fakeData = function fakeData(themeFile) {
     };
 
     // Initialise data for index/home hbs templates
-    var postsData = {posts: [post], pagination: {}};
+    let postsData = {posts: [post], pagination: {}};
 
     if (themeFile.file.match(/^post/) || themeFile.file.match(/^page/)) {
         postsData = {post: post};

--- a/lib/format.js
+++ b/lib/format.js
@@ -31,13 +31,13 @@ const format = function format(theme, options = {}) {
     const checkVersion = _.get(options, 'checkVersion', versions.default);
     const ruleSet = spec.get([checkVersion]);
 
-    var processedCodes = [],
-        hasFatalErrors = false,
-        stats = {
-            error: 0,
-            warning: 0,
-            recommendation: 0
-        };
+    const processedCodes = [];
+    let hasFatalErrors = false;
+    const stats = {
+        error: 0,
+        warning: 0,
+        recommendation: 0
+    };
 
     theme.results.error = [];
     theme.results.warning = [];

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -24,12 +24,12 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
     themePath = path.join(themePath, '.');
     subPath = subPath || '';
 
-    var tmpPath = os.tmpdir(),
-        inTmp = themePath.substr(0, tmpPath.length) === tmpPath;
+    const tmpPath = os.tmpdir();
+    const inTmp = themePath.substr(0, tmpPath.length) === tmpPath;
 
     arr = arr || [];
 
-    var makeResult = function makeResult(result, subFilePath, ext, symlink) {
+    const makeResult = function makeResult(result, subFilePath, ext, symlink) {
         result.push({
             file: subFilePath,
             normalizedFile: normalizePath(subFilePath),
@@ -163,36 +163,36 @@ const processHelpers = function (theme, themeFile) {
  * this function is outsourced in the future, so it can be used by GScan and Ghost. But for now, we don't pre-optimise.
  */
 const extractCustomTemplates = function extractCustomTemplates(allTemplates) {
-    var toReturn = [],
-        generateName = function generateName(templateName) {
-            var name = templateName;
+    const toReturn = [];
+    const generateName = function generateName(templateName) {
+        let name = templateName;
 
-            name = name.replace(/^(post-|page-|custom-)/, '');
-            name = name.replace(/-/g, ' ');
-            name = name.replace(/\b\w/g, function (letter) {
-                return letter.toUpperCase();
-            });
+        name = name.replace(/^(post-|page-|custom-)/, '');
+        name = name.replace(/-/g, ' ');
+        name = name.replace(/\b\w/g, function (letter) {
+            return letter.toUpperCase();
+        });
 
-            return name.trim();
-        },
-        generateFor = function (templateName) {
-            if (templateName.match(/^page-/)) {
-                return ['page'];
-            }
+        return name.trim();
+    };
+    const generateFor = function (templateName) {
+        if (templateName.match(/^page-/)) {
+            return ['page'];
+        }
 
-            if (templateName.match(/^post-/)) {
-                return ['post'];
-            }
+        if (templateName.match(/^post-/)) {
+            return ['post'];
+        }
 
-            return ['page', 'post'];
-        },
-        generateSlug = function (templateName) {
-            if (templateName.match(/^custom-/)) {
-                return null;
-            }
+        return ['page', 'post'];
+    };
+    const generateSlug = function (templateName) {
+        if (templateName.match(/^custom-/)) {
+            return null;
+        }
 
-            return templateName.match(/^(page-|post-)(.*)/)[2];
-        };
+        return templateName.match(/^(page-|post-)(.*)/)[2];
+    };
 
     _.each(allTemplates, function (templateName) {
         if (templateName.match(/^(post-|page-|custom-)/) && !templateName.match(/\//)) {
@@ -223,7 +223,7 @@ const extractTemplates = function extractTemplates(allFiles) {
             return templates;
         }
 
-        var tplMatch = entry.file.match(/(.*)\.hbs$/);
+        const tplMatch = entry.file.match(/(.*)\.hbs$/);
         if (tplMatch) {
             templates.push(tplMatch[1]);
         }
@@ -239,7 +239,7 @@ const extractTemplates = function extractTemplates(allFiles) {
 module.exports = function readTheme(themePath) {
     return readThemeStructure(themePath)
         .then(function (themeFiles) {
-            var allTemplates = extractTemplates(themeFiles);
+            const allTemplates = extractTemplates(themeFiles);
 
             return readFiles({
                 path: themePath,

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -5,7 +5,7 @@
  */
 const oneLineTrim = require('../utils/one-line-trim');
 const docsBaseUrl = `https://ghost.org/docs/themes/`;
-let knownHelpers, templates, rules, ruleNext;
+let knownHelpers; let templates; let rules; let ruleNext;
 
 knownHelpers = [
     // Ghost

--- a/lib/utils/score-calculator.js
+++ b/lib/utils/score-calculator.js
@@ -19,7 +19,7 @@ const levelWeights = {
 * @returns {Object}
  */
 const calcScore = function calcScore(results, stats) {
-    var maxScore, actualScore, balancedScore;
+    let maxScore; let actualScore; let balancedScore;
 
     maxScore = _.reduce(levelWeights, function (max, weight, level) {
         return max + (weight * stats[level]);

--- a/test/005-template-compile.test.js
+++ b/test/005-template-compile.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/005-template-compile');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/005-template-compile');
 
 describe('005 Template compile', function () {
     describe('v1', function () {
@@ -39,7 +39,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(4);
 
@@ -116,7 +116,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(4);
 
@@ -193,7 +193,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(4);
 
@@ -283,7 +283,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(4);
 
@@ -311,7 +311,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(1);
 
@@ -330,7 +330,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(1);
 
@@ -349,7 +349,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(1);
 
@@ -453,7 +453,7 @@ describe('005 Template compile', function () {
                 output.results.fail.should.be.an.Object().with.keys('GS005-TPL-ERR');
                 output.results.fail['GS005-TPL-ERR'].should.be.a.ValidFailObject();
 
-                var failures = output.results.fail['GS005-TPL-ERR'].failures;
+                const failures = output.results.fail['GS005-TPL-ERR'].failures;
 
                 failures.length.should.eql(1);
 
@@ -502,7 +502,7 @@ describe('005 Template compile', function () {
 
                 output.results.fail.should.be.an.Object().which.is.empty();
 
-                let helperList = Object.keys(output.helpers);
+                const helperList = Object.keys(output.helpers);
                 helperList.should.be.an.Array().with.lengthOf(1);
                 helperList.should.containEql('cancel_link');
 

--- a/test/010-package-json.test.js
+++ b/test/010-package-json.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/010-package-json');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/010-package-json');
 
 const fs = require('fs').promises;
 const path = require('path');

--- a/test/020-theme-structure.test.js
+++ b/test/020-theme-structure.test.js
@@ -1,7 +1,7 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
 
-    thisCheck = require('../lib/checks/020-theme-structure');
+const thisCheck = require('../lib/checks/020-theme-structure');
 
 describe('020 Theme structure', function () {
     const options = {checkVersion: 'v3'};

--- a/test/030-assets.test.js
+++ b/test/030-assets.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/030-assets');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/030-assets');
 
 describe('030 Assets', function () {
     const options = {checkVersion: 'v3'};

--- a/test/050-koenig-css-classes.test.js
+++ b/test/050-koenig-css-classes.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/050-koenig-css-classes');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/050-koenig-css-classes');
 
 describe('050 Koenig CSS classes', function () {
     describe('v1:', function () {

--- a/test/060-js-api-usage.test.js
+++ b/test/060-js-api-usage.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/060-js-api-usage');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/060-js-api-usage');
 
 describe('060 JS API USAGE', function () {
     describe('v1:', function () {

--- a/test/090-template-syntax.test.js
+++ b/test/090-template-syntax.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/090-template-syntax');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/090-template-syntax');
 
 describe('090 Template syntax', function () {
     describe('v4', function () {

--- a/test/110-page-builder-usage.test.js
+++ b/test/110-page-builder-usage.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/110-page-builder-usage');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/110-page-builder-usage');
 
 describe('110 Page-builder usage', function () {
     describe('v5', function () {

--- a/test/120-no-unknown-globals.test.js
+++ b/test/120-no-unknown-globals.test.js
@@ -1,6 +1,6 @@
-var should = require('should'), // eslint-disable-line no-unused-vars
-    utils = require('./utils'),
-    thisCheck = require('../lib/checks/120-no-unknown-globals');
+const should = require('should'); // eslint-disable-line no-unused-vars
+const utils = require('./utils');
+const thisCheck = require('../lib/checks/120-no-unknown-globals');
 
 describe('120 No unknown globals', function () {
     describe('v5', function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
-var path = require('path'),
-    should = require('should'),
-    readTheme = require('../lib/read-theme'),
-    testThemePath = 'test/fixtures/themes';
+const path = require('path');
+const should = require('should');
+const readTheme = require('../lib/read-theme');
+const testThemePath = 'test/fixtures/themes';
 
 should.Assertion.add('ValidResultObject', function () {
     this.params = {operator: 'to be valid result object'};
@@ -43,7 +43,7 @@ should.Assertion.add('ValidFailObject', function () {
 });
 
 should.Assertion.add('ValidRule', function () {
-    var levels = ['error', 'warning', 'recommendation', 'feature']; // eslint-disable-line no-unused-vars
+    const levels = ['error', 'warning', 'recommendation', 'feature']; // eslint-disable-line no-unused-vars
 });
 
 const getThemePath = function (themeId) {
@@ -51,7 +51,7 @@ const getThemePath = function (themeId) {
 };
 
 const testCheck = function testCheck(checkLib, themeId, options) {
-    var themePath = getThemePath(themeId);
+    const themePath = getThemePath(themeId);
 
     return readTheme(themePath).then(function runCheck(theme) {
         return checkLib.call(this, theme, options, themePath);


### PR DESCRIPTION
no ref

- cleans up variable declarations to use let/const instead of var
- lint rule just required `no-var`, so at first a lot were `let` from running `yarn lint --fix` but updated to `const` where it made sense
- some of these are (probably) unnecessarily included with `no-unused-vars`, that'll be cleaned up separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical variable-declaration refactor (`var` -> `const`/`let`) with no intended behavior changes; risk is limited to potential scoping/immutability mistakes in a few touched utility paths.
> 
> **Overview**
> Refactors various middleware, theme-scanning checks/utilities, and tests to satisfy `no-var` linting by replacing `var` with block-scoped `const`/`let` and splitting multi-variable declarations.
> 
> No functional logic changes are intended; updates are largely mechanical and include minor readability tweaks in places like `read-theme`, `format`, and several check/test files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e38178da916fc5b4b1feaa6c92c159659224bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->