### PR TITLE
Updated eslint config to prepare for Vitest migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,8 @@ const ghostTestConfig = {
     ...withGhostPlugin(ghostPlugin.configs.test),
     rules: {
         ...ghostPlugin.configs.test.rules,
-        'ghost/ghost-custom/no-native-error': 'off'
+        'ghost/ghost-custom/no-native-error': 'off',
+        'padded-blocks': 'off'
     }
 };
 
@@ -43,7 +44,21 @@ module.exports = [
     ...fixupConfigRules(compat.config(ghostNodeConfig)),
     ...fixupConfigRules(compat.config(ghostTestConfig)).map(config => ({
         ...config,
-        files: ['test/**/*.js']
+        files: ['test/**/*.js'],
+        languageOptions: {
+            ...(config.languageOptions || {}),
+            globals: {
+                ...(config.languageOptions && config.languageOptions.globals ? config.languageOptions.globals : {}),
+                afterAll: 'readonly',
+                afterEach: 'readonly',
+                beforeAll: 'readonly',
+                beforeEach: 'readonly',
+                describe: 'readonly',
+                expect: 'readonly',
+                it: 'readonly',
+                test: 'readonly'
+            }
+        }
     })),
     ...fixupConfigRules(compat.config(ghostBrowserConfig)).map(config => ({
         ...config,

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "2.0.3",
+    "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
     "@tryghost/pro-ship": "1.0.7",
     "c8": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,7 +128,7 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
 
-"@eslint/eslintrc@^3.3.5":
+"@eslint/eslintrc@3.3.5", "@eslint/eslintrc@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.5.tgz#c131793cfc1a7b96f24a83e0a8bbd4b881558c60"
   integrity sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==


### PR DESCRIPTION
no ref

- adds a few configurations to eslint to prepare to move from `mocha` to `vitest` 
- should have no impact on the current codebase
- this could go in the mocha -> vitest PR, but since the migration will have a lot of files merging this will make that just a bit easier to review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates lint configuration and devDependencies, with no runtime or production code changes. Main impact is altered lint behavior in `test/**/*.js` which could mask/allow some formatting issues.
> 
> **Overview**
> Prepares `test/**/*.js` linting for upcoming Vitest work by disabling `padded-blocks` for the test config and explicitly defining common test globals (`describe`, `it`, `expect`, `beforeEach`, etc.) to avoid undefined-global lint errors.
> 
> Adds `@eslint/eslintrc@3.3.5` to `devDependencies` (and updates `yarn.lock`) to support the flat-config setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f32b436e6e92a7d46640a098ade455c01bc722. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->