### PR TITLE
Added tests for CLI and minor refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,15 +102,18 @@ themePath('030-assets/valid')  // Returns fixture path
 testCheck(theme, checkName, expectedFailCodes)  // Validates check results
 ```
 
+### Assertions
+New tests must use vitest's `expect` (available globally via `globals: true` in vitest config). Do not use `should` — it is legacy and being removed from the codebase. Existing tests still use `should` but should not be taken as a pattern to follow.
+
 ### Common Test Patterns
 ```javascript
 // Testing a passing theme
 const theme = await check(themePath('valid-theme'));
-theme.results.pass.should.containEql('GS010-PJ-REQ');
+expect(theme.results.pass).toContain('GS010-PJ-REQ');
 
 // Testing failures
 const theme = await check(themePath('invalid-theme'));
-theme.results.fail['GS010-PJ-NAME-REQ'].should.exist();
+expect(theme.results.fail['GS010-PJ-NAME-REQ']).toBeDefined();
 ```
 
 ## Debugging
@@ -196,13 +199,13 @@ Themes can define custom settings in package.json:
    describe('XXX Check name', function () {
        it('should detect the issue', async function () {
            const output = await utils.testCheck(checkSomething, 'XXX-check-name/failing-case');
-           output.results.fail['GSXXX-ERROR-CODE'].should.exist();
+           expect(output.results.fail['GSXXX-ERROR-CODE']).toBeDefined();
        });
    });
    ```
 
 5. **Update checker test expectations** in `test/checker.test.js`:
-   - Add 1 to the `lengthOf()` count for each version's pass array
+   - Add 1 to the pass array length count for each version
    - Add the new rule code to the exact position in the pass arrays (they're alphabetically sorted)
    - Run tests to see where the rule should be positioned
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// Remove all Node warnings before doing anything else
-process.removeAllListeners('warning');
-
 const prettyCLI = require('@tryghost/pretty-cli');
 const ui = require('@tryghost/pretty-cli').ui;
 const _ = require('lodash');
@@ -17,114 +14,65 @@ const levels = {
     feature: chalk.green
 };
 
-const cliOptions = {
-    format: 'cli'
-};
+function resolveOptions(argv) {
+    const options = {format: 'cli'};
 
-prettyCLI
-    .configure({
-        name: 'gscan'
-    })
-    .groupOrder([
-        'Sources:',
-        'Utilities:',
-        'Commands:',
-        'Arguments:',
-        'Required Options:',
-        'Options:',
-        'Global Options:'
-    ])
-    .positional('<themePath>', {
-        paramsDesc: 'Theme folder or .zip file path',
-        mustExist: true
-    })
-    .boolean('-z, --zip', {
-        desc: 'Theme path points to a zip file'
-    })
-    .boolean('-1, --v1', {
-        desc: 'Check theme for Ghost 1.0 compatibility'
-    })
-    .boolean('-2, --v2', {
-        desc: 'Check theme for Ghost 2.0 compatibility'
-    })
-    .boolean('-3, --v3', {
-        desc: 'Check theme for Ghost 3.0 compatibility'
-    })
-    .boolean('-4, --v4', {
-        desc: 'Check theme for Ghost 4.0 compatibility'
-    })
-    .boolean('-5, --v5', {
-        desc: 'Check theme for Ghost 5.0 compatibility'
-    })
-    .boolean('-6, --v6', {
-        desc: 'Check theme for Ghost 6.0 compatibility'
-    })
-    .boolean('-c, --canary', {
-        desc: 'Check theme for Ghost 6.0 compatibility (alias for --v6)'
-    })
-    .boolean('-f, --fatal', {
-        desc: 'Only show fatal errors that prevent upgrading Ghost'
-    })
-    .boolean('--verbose', {
-        desc: 'Output check details'
-    })
-    .array('--labs', {
-        desc: 'a list of labs flags'
-    })
-    .parseAndExit()
-    .then((argv) => {
-        if (argv.v1) {
-            cliOptions.checkVersion = 'v1';
-        } else if (argv.v2) {
-            cliOptions.checkVersion = 'v2';
-        } else if (argv.v3) {
-            cliOptions.checkVersion = 'v3';
-        } else if (argv.v4) {
-            cliOptions.checkVersion = 'v4';
-        } else if (argv.v5) {
-            cliOptions.checkVersion = 'v5';
-        } else if (argv.v6) {
-            cliOptions.checkVersion = 'v6';
-        } else if (argv.canary) {
-            cliOptions.checkVersion = ghostVersions.canary;
-        } else {
-            cliOptions.checkVersion = ghostVersions.default;
-        }
+    if (argv.v1) {
+        options.checkVersion = 'v1';
+    } else if (argv.v2) {
+        options.checkVersion = 'v2';
+    } else if (argv.v3) {
+        options.checkVersion = 'v3';
+    } else if (argv.v4) {
+        options.checkVersion = 'v4';
+    } else if (argv.v5) {
+        options.checkVersion = 'v5';
+    } else if (argv.v6) {
+        options.checkVersion = 'v6';
+    } else if (argv.canary) {
+        options.checkVersion = ghostVersions.canary;
+    } else {
+        options.checkVersion = ghostVersions.default;
+    }
 
-        cliOptions.verbose = argv.verbose;
-        cliOptions.onlyFatalErrors = argv.fatal;
+    options.verbose = argv.verbose;
+    options.onlyFatalErrors = argv.fatal;
 
-        if (argv.labs) {
-            cliOptions.labs = {};
+    if (argv.labs) {
+        options.labs = {};
 
-            argv.labs.forEach((flag) => {
-                cliOptions.labs[flag] = true;
+        argv.labs.forEach((flag) => {
+            options.labs[flag] = true;
+        });
+    }
+
+    return options;
+}
+
+function runCheck(argv, options) {
+    if (options.onlyFatalErrors) {
+        ui.log(chalk.bold('\nChecking theme compatibility (fatal issues only)...'));
+    } else {
+        ui.log(chalk.bold('\nChecking theme compatibility...'));
+    }
+
+    if (argv.zip) {
+        return gscan.checkZip(argv.themePath, options)
+            .then(theme => outputResults(theme, options))
+            .catch((error) => {
+                ui.log(error);
             });
-        }
-
-        if (cliOptions.onlyFatalErrors) {
-            ui.log(chalk.bold('\nChecking theme compatibility (fatal issues only)...'));
-        } else {
-            ui.log(chalk.bold('\nChecking theme compatibility...'));
-        }
-
-        if (argv.zip) {
-            gscan.checkZip(argv.themePath, cliOptions)
-                .then(theme => outputResults(theme, cliOptions))
-                .catch((error) => {
-                    ui.log(error);
-                });
-        } else {
-            gscan.check(argv.themePath, cliOptions)
-                .then(theme => outputResults(theme, cliOptions))
-                .catch((err) => {
-                    ui.log(err.message);
-                    if (err.code === 'ENOTDIR') {
-                        ui.log('Did you mean to add the -z flag to read a zip file?');
-                    }
-                });
-        }
-    });
+    } else {
+        return gscan.check(argv.themePath, options)
+            .then(theme => outputResults(theme, options))
+            .catch((err) => {
+                ui.log(err.message);
+                if (err.code === 'ENOTDIR') {
+                    ui.log('Did you mean to add the -z flag to read a zip file?');
+                }
+            });
+    }
+}
 
 function outputResult(result, options) {
     ui.log(levels[result.level](`- ${_.capitalize(result.level)}:`), result.rule);
@@ -229,7 +177,7 @@ function outputResults(theme, options) {
         _.each(theme.results.recommendation, rule => outputResult(rule, options));
     }
 
-    ui.log(`\nGet more help at ${chalk.cyan.underline('https://ghost.org/docs/themes/')}`);
+    ui.log(`\nGet more help at ${chalk.cyan.underline('https://docs.ghost.org/themes/')}`);
     ui.log(`You can also check theme compatibility at ${chalk.cyan.underline('https://gscan.ghost.org/')}`);
 
     // The CLI feature is mainly used to run gscan programatically in tests within themes.
@@ -243,4 +191,70 @@ function outputResults(theme, options) {
     } else {
         process.exit(0);
     }
+}
+
+function main() {
+    prettyCLI
+        .configure({
+            name: 'gscan'
+        })
+        .groupOrder([
+            'Sources:',
+            'Utilities:',
+            'Commands:',
+            'Arguments:',
+            'Required Options:',
+            'Options:',
+            'Global Options:'
+        ])
+        .positional('<themePath>', {
+            paramsDesc: 'Theme folder or .zip file path',
+            mustExist: true
+        })
+        .boolean('-z, --zip', {
+            desc: 'Theme path points to a zip file'
+        })
+        .boolean('-1, --v1', {
+            desc: 'Check theme for Ghost 1.0 compatibility'
+        })
+        .boolean('-2, --v2', {
+            desc: 'Check theme for Ghost 2.0 compatibility'
+        })
+        .boolean('-3, --v3', {
+            desc: 'Check theme for Ghost 3.0 compatibility'
+        })
+        .boolean('-4, --v4', {
+            desc: 'Check theme for Ghost 4.0 compatibility'
+        })
+        .boolean('-5, --v5', {
+            desc: 'Check theme for Ghost 5.0 compatibility'
+        })
+        .boolean('-6, --v6', {
+            desc: 'Check theme for Ghost 6.0 compatibility'
+        })
+        .boolean('-c, --canary', {
+            desc: 'Check theme for Ghost 6.0 compatibility (alias for --v6)'
+        })
+        .boolean('-f, --fatal', {
+            desc: 'Only show fatal errors that prevent upgrading Ghost'
+        })
+        .boolean('--verbose', {
+            desc: 'Output check details'
+        })
+        .array('--labs', {
+            desc: 'a list of labs flags'
+        })
+        .parseAndExit()
+        .then((argv) => {
+            const options = resolveOptions(argv);
+            runCheck(argv, options);
+        });
+}
+
+module.exports = {formatCount, getSummary, outputResult, outputResults, resolveOptions, runCheck};
+
+if (require.main === module) {
+    // Remove all Node warnings only when run as a CLI, not when imported as a module
+    process.removeAllListeners('warning');
+    main();
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ const ghostTestConfig = {
     rules: {
         ...ghostPlugin.configs.test.rules,
         'ghost/ghost-custom/no-native-error': 'off',
+        'ghost/mocha/no-setup-in-describe': 'off',
         'padded-blocks': 'off'
     }
 };

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -1,0 +1,93 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CLI > CLI binary (smoke test) > should boot, parse args, check a theme, and exit 1`] = `
+"
+Checking theme compatibility...
+
+Your theme has 20 errors and 7 warnings!
+---
+
+Errors
+---
+Important to fix, functionality may be degraded.
+
+- Error: A template file called post.hbs must be present
+Affected Files: post.hbs
+
+- Error: package.json file can be parsed
+Affected Files: package.json
+
+- Error: package.json property "name" is required
+
+- Error: package.json property "name" must be lowercase
+
+- Error: package.json property "name" must be hyphenated
+
+- Error: package.json property "version" must be semver compliant
+
+- Error: package.json property "version" is required
+
+- Error: package.json property "author.email" must be valid
+
+- Error: package.json property "author.email" is required
+
+- Error: package.json property "config.custom" contains too many settings
+
+- Error: package.json property "config.custom" contains a property that isn't snake-cased
+
+- Error: package.json objects defined in "config.custom" should have a known "type".
+
+- Error: package.json objects defined in "config.custom" of type "select" need to have at least 2 "options".
+
+- Error: package.json objects defined in "config.custom" of type "select" need to have a valid "default".
+
+- Error: package.json objects defined in "config.custom" of type "boolean" need to have a valid "default".
+
+- Error: package.json objects defined in "config.custom" of type "color" need to have a valid "default".
+
+- Error: package.json objects defined in "config.custom" of type "image" can't have a "default" value.
+
+- Error: The .kg-width-wide CSS class is required to appear styled in your theme
+Affected Files: styles
+
+- Error: The .kg-width-full CSS class is required to appear styled in your theme
+Affected Files: styles
+
+- Error: Not all page features are being used
+Affected Files: page.hbs
+
+
+Warnings
+---
+- Warning: package.json property keywords should contain ghost-theme
+
+- Warning: Remove "engines.ghost-api" from package.json
+
+- Warning: "card_assets" will now be included by default, including bookmark and gallery cards.
+
+- Warning: package.json property config.custom contains an entry with a description that is too long
+
+- Warning: The helper {{ghost_head}} should be present
+Affected Files: default.hbs
+
+- Warning: The helper {{ghost_foot}} should be present
+Affected Files: default.hbs
+
+- Warning: Missing support for custom fonts
+Affected Files: styles
+
+
+Recommendations
+---
+- Recommendation: package.json property "config.posts_per_page" is recommended. Otherwise, it falls back to 5
+
+- Recommendation: package.json objects defined in "config.custom" should have a known "group".
+
+- Recommendation: Provide a default layout template called default.hbs
+Affected Files: default.hbs
+
+
+Get more help at https://docs.ghost.org/themes/
+You can also check theme compatibility at https://gscan.ghost.org/
+"
+`;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,419 @@
+const path = require('path');
+const {execFileSync} = require('child_process');
+const stripAnsi = require('strip-ansi');
+const prettyCli = require('@tryghost/pretty-cli');
+const gscan = require('../lib');
+
+const mockLog = vi.fn();
+mockLog.error = vi.fn();
+
+// Save original and override ui.log on the shared module object
+// so bin/cli.js (which holds a reference to the same ui object) sees the mock
+const originalLog = prettyCli.ui.log;
+prettyCli.ui.log = mockLog;
+
+const {formatCount, getSummary, outputResult, outputResults, resolveOptions, runCheck} = require('../bin/cli');
+const ghostVersions = require('../lib/utils').versions;
+
+// Formatted fixtures for functions that consume post-format data (getSummary, outputResult)
+const cleanFormatted = {
+    checkedVersion: '6.x',
+    results: {error: [], warning: [], recommendation: []}
+};
+
+const errorFormatted = {
+    checkedVersion: '6.x',
+    results: {
+        error: [{level: 'error', rule: 'Missing index.hbs', details: 'Need index', failures: [{ref: 'index.hbs'}]}],
+        warning: [],
+        recommendation: []
+    }
+};
+
+const mixedFormatted = {
+    checkedVersion: '6.x',
+    results: {
+        error: [{level: 'error', rule: 'Error rule', details: 'Error details', failures: [{ref: 'a.hbs'}]}],
+        warning: [{level: 'warning', rule: 'Warning rule', details: 'Warning details', failures: [{ref: 'b.hbs'}]}],
+        recommendation: [{level: 'recommendation', rule: 'Rec rule', details: 'Rec details', failures: [{ref: 'c.hbs'}]}]
+    }
+};
+
+const warningOnlyFormatted = {
+    checkedVersion: '6.x',
+    results: {
+        error: [],
+        warning: [{level: 'warning', rule: 'Warning rule', details: 'Warning details', failures: [{ref: 'b.hbs'}]}],
+        recommendation: []
+    }
+};
+
+// Raw (pre-format) fixtures for outputResults, which calls gscan.format internally.
+// format() mutates the theme, so these must be deep-cloned before each use.
+const rawClean = {
+    results: {
+        pass: ['GS020-INDEX-REQ', 'GS020-POST-REQ'],
+        fail: {}
+    }
+};
+
+const rawWithErrors = {
+    results: {
+        pass: [],
+        fail: {
+            'GS020-INDEX-REQ': {failures: [{ref: 'index.hbs'}]},
+            'GS020-POST-REQ': {failures: [{ref: 'post.hbs'}]}
+        }
+    }
+};
+
+const rawWithWarnings = {
+    results: {
+        pass: [],
+        fail: {
+            'GS030-ASSET-REQ': {failures: [{ref: 'assets/'}]}
+        }
+    }
+};
+
+const rawWithRecommendations = {
+    results: {
+        pass: [],
+        fail: {
+            'GS010-PJ-CONF-PPP': {failures: [{ref: 'package.json'}]}
+        }
+    }
+};
+
+const rawMixed = {
+    results: {
+        pass: [],
+        fail: {
+            'GS020-INDEX-REQ': {failures: [{ref: 'index.hbs'}]},
+            'GS030-ASSET-REQ': {failures: [{ref: 'assets/'}]},
+            'GS010-PJ-CONF-PPP': {failures: [{ref: 'package.json'}]}
+        }
+    }
+};
+
+function allLogOutput() {
+    return mockLog.mock.calls.map(c => c.join(' ')).join('\n');
+}
+
+describe('CLI', function () {
+    afterAll(function () {
+        prettyCli.ui.log = originalLog;
+    });
+
+    beforeEach(function () {
+        mockLog.mockClear();
+        mockLog.error.mockClear();
+    });
+
+    describe('formatCount', function () {
+        it('should use singular for count of 1', function () {
+            expect(formatCount('error', 1)).toBe('1 error');
+        });
+
+        it('should use plural for count of 2', function () {
+            expect(formatCount('error', 2)).toBe('2 errors');
+        });
+
+        it('should use plural for count of 0', function () {
+            expect(formatCount('warning', 0)).toBe('0 warnings');
+        });
+    });
+
+    describe('getSummary', function () {
+        it('should show compatible message for clean theme', function () {
+            expect(getSummary(cleanFormatted, {})).toContain('Your theme is compatible with Ghost 6.x');
+        });
+
+        it('should show no fatal issues message when onlyFatalErrors is true', function () {
+            expect(getSummary(cleanFormatted, {onlyFatalErrors: true})).toContain('no fatal compatibility issues');
+        });
+
+        it('should show error count for theme with errors', function () {
+            const summary = getSummary(errorFormatted, {});
+            expect(summary).toContain('Your theme has');
+            expect(summary).toContain('error');
+        });
+
+        it('should show errors and warnings for mixed theme', function () {
+            const summary = getSummary(mixedFormatted, {});
+            expect(summary).toContain('error');
+            expect(summary).toContain('and');
+            expect(summary).toContain('warning');
+        });
+
+        it('should show only warnings when no errors', function () {
+            const summary = getSummary(warningOnlyFormatted, {});
+            expect(summary).toContain('warning');
+            expect(summary).toContain('Your theme has');
+        });
+
+        it('should include separator line when issues present', function () {
+            const summary = getSummary(errorFormatted, {});
+            // Summary adds \n + dashes after the issue text
+            // Dashes may be empty when chalk doesn't output ANSI codes (test env)
+            expect(summary).toContain('!\n');
+        });
+    });
+
+    describe('outputResult', function () {
+        it('should log level and rule in non-verbose mode', function () {
+            const result = {level: 'error', rule: 'Missing index.hbs', details: 'Need index', failures: [{ref: 'index.hbs'}]};
+            outputResult(result, {});
+
+            expect(allLogOutput()).toContain('Error:');
+            expect(allLogOutput()).toContain('Missing index.hbs');
+        });
+
+        it('should log affected files with comma-joined refs in non-verbose mode', function () {
+            const result = {level: 'warning', rule: 'Some rule', details: 'Details', failures: [{ref: 'a.hbs'}, {ref: 'b.hbs'}]};
+            outputResult(result, {});
+
+            expect(allLogOutput()).toContain('Affected Files:');
+            expect(allLogOutput()).toContain('a.hbs, b.hbs');
+        });
+
+        it('should log details in verbose mode', function () {
+            const result = {level: 'error', rule: 'Some rule', details: 'Detailed explanation', failures: [{ref: 'a.hbs'}]};
+            outputResult(result, {verbose: true});
+
+            expect(allLogOutput()).toContain('Details:');
+            expect(allLogOutput()).toContain('Detailed explanation');
+        });
+
+        it('should log individual refs in verbose mode', function () {
+            const result = {level: 'error', rule: 'Some rule', details: 'Details', failures: [{ref: 'a.hbs'}, {ref: 'b.hbs'}]};
+            outputResult(result, {verbose: true});
+
+            expect(allLogOutput()).toContain('Affected Files:');
+            expect(allLogOutput()).toContain('a.hbs');
+            expect(allLogOutput()).toContain('b.hbs');
+        });
+
+        it('should append failure message to ref in verbose mode', function () {
+            const result = {level: 'error', rule: 'Some rule', details: 'Details', failures: [{ref: 'a.hbs', message: 'custom message'}]};
+            outputResult(result, {verbose: true});
+
+            expect(allLogOutput()).toContain('a.hbs - custom message');
+        });
+
+        it('should not log affected files when there are no failures', function () {
+            const result = {level: 'error', rule: 'Some rule', details: 'Details', failures: []};
+            outputResult(result, {});
+
+            expect(allLogOutput()).not.toContain('Affected Files:');
+        });
+
+        it('should deduplicate refs in non-verbose mode', function () {
+            const result = {level: 'error', rule: 'Some rule', details: 'Details', failures: [{ref: 'a.hbs'}, {ref: 'a.hbs'}]};
+            outputResult(result, {});
+
+            const affectedLine = mockLog.mock.calls.find(c => c.join(' ').includes('Affected Files:'));
+            expect(affectedLine).toBeDefined();
+            const lineText = affectedLine.join(' ');
+            expect(lineText).toContain('a.hbs');
+            expect(lineText).not.toContain('a.hbs, a.hbs');
+        });
+    });
+
+    describe('outputResults', function () {
+        const formatOptions = {checkVersion: 'v6', format: 'cli'};
+        let exitSpy;
+
+        beforeEach(function () {
+            exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+        });
+
+        afterEach(function () {
+            exitSpy.mockRestore();
+        });
+
+        it('should exit with code 1 when errors are present', function () {
+            outputResults(structuredClone(rawWithErrors), formatOptions);
+
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('should exit with code 0 when no errors', function () {
+            outputResults(structuredClone(rawClean), formatOptions);
+
+            expect(exitSpy).toHaveBeenCalledWith(0);
+        });
+
+        it('should log Errors section header when errors present', function () {
+            outputResults(structuredClone(rawWithErrors), formatOptions);
+
+            expect(allLogOutput()).toContain('Errors');
+        });
+
+        it('should log Warnings section header when warnings present', function () {
+            outputResults(structuredClone(rawWithWarnings), formatOptions);
+
+            expect(allLogOutput()).toContain('Warnings');
+        });
+
+        it('should log Recommendations section header when recommendations present', function () {
+            outputResults(structuredClone(rawWithRecommendations), formatOptions);
+
+            expect(allLogOutput()).toContain('Recommendations');
+        });
+
+        it('should log help links', function () {
+            outputResults(structuredClone(rawClean), formatOptions);
+
+            expect(allLogOutput()).toContain('docs.ghost.org/themes/');
+            expect(allLogOutput()).toContain('gscan.ghost.org');
+        });
+
+        it('should log all section headers for mixed results', function () {
+            outputResults(structuredClone(rawMixed), formatOptions);
+
+            const output = allLogOutput();
+            expect(output).toContain('Errors');
+            expect(output).toContain('Warnings');
+            expect(output).toContain('Recommendations');
+        });
+
+        it('should handle gscan.format throwing an error', function () {
+            // A nonexistent rule code causes format to throw after setting up result arrays
+            outputResults({results: {pass: [], fail: {'NONEXISTENT-CODE': {failures: []}}}}, formatOptions);
+
+            expect(mockLog.error).toHaveBeenCalled();
+            const errorOutput = mockLog.error.mock.calls.map(c => c.join(' ')).join('\n');
+            expect(errorOutput).toContain('Error formating result');
+        });
+    });
+
+    describe('resolveOptions', function () {
+        Object.keys(ghostVersions).filter(k => k.startsWith('v')).forEach(function (version) {
+            it(`should resolve ${version} flag`, function () {
+                expect(resolveOptions({[version]: true}).checkVersion).toBe(version);
+            });
+        });
+
+        it('should resolve canary flag', function () {
+            expect(resolveOptions({canary: true}).checkVersion).toBe(ghostVersions.canary);
+        });
+
+        it('should use default version when no flag set', function () {
+            expect(resolveOptions({}).checkVersion).toBe(ghostVersions.default);
+        });
+
+        it('should set verbose from argv', function () {
+            expect(resolveOptions({verbose: true}).verbose).toBe(true);
+        });
+
+        it('should set onlyFatalErrors from argv.fatal', function () {
+            expect(resolveOptions({fatal: true}).onlyFatalErrors).toBe(true);
+        });
+
+        it('should parse labs flags', function () {
+            const options = resolveOptions({labs: ['portalFlag', 'anotherFlag']});
+            expect(options.labs).toEqual({portalFlag: true, anotherFlag: true});
+        });
+
+        it('should not set labs when not provided', function () {
+            expect(resolveOptions({}).labs).toBeUndefined();
+        });
+
+        it('should always include format: cli', function () {
+            expect(resolveOptions({}).format).toBe('cli');
+        });
+    });
+
+    describe('runCheck', function () {
+        let originalCheck;
+        let originalCheckZip;
+
+        beforeEach(function () {
+            originalCheck = gscan.check;
+            originalCheckZip = gscan.checkZip;
+        });
+
+        afterEach(function () {
+            gscan.check = originalCheck;
+            gscan.checkZip = originalCheckZip;
+        });
+
+        it('should log fatal-only message when onlyFatalErrors is true', function () {
+            gscan.check = vi.fn(() => new Promise(() => {}));
+            runCheck({themePath: '/tmp/theme'}, {onlyFatalErrors: true});
+
+            expect(allLogOutput()).toContain('fatal issues only');
+        });
+
+        it('should log standard message when onlyFatalErrors is false', function () {
+            gscan.check = vi.fn(() => new Promise(() => {}));
+            runCheck({themePath: '/tmp/theme'}, {});
+
+            expect(allLogOutput()).toContain('Checking theme compatibility...');
+            expect(allLogOutput()).not.toContain('fatal');
+        });
+
+        it('should call checkZip when zip flag is set', function () {
+            gscan.checkZip = vi.fn(() => new Promise(() => {}));
+            runCheck({zip: true, themePath: '/tmp/theme.zip'}, {});
+
+            expect(gscan.checkZip).toHaveBeenCalledWith('/tmp/theme.zip', {});
+        });
+
+        it('should call check when zip flag is not set', function () {
+            gscan.check = vi.fn(() => new Promise(() => {}));
+            runCheck({themePath: '/tmp/theme'}, {});
+
+            expect(gscan.check).toHaveBeenCalledWith('/tmp/theme', {});
+        });
+
+        it('should handle check errors', async function () {
+            gscan.check = vi.fn(() => Promise.reject(new Error('check failed')));
+            await runCheck({themePath: '/tmp/theme'}, {});
+
+            expect(allLogOutput()).toContain('check failed');
+        });
+
+        it('should suggest zip flag on ENOTDIR error', async function () {
+            const err = new Error('not a directory');
+            err.code = 'ENOTDIR';
+            gscan.check = vi.fn(() => Promise.reject(err));
+            await runCheck({themePath: '/tmp/theme.zip'}, {});
+
+            expect(allLogOutput()).toContain('Did you mean to add the -z flag');
+        });
+
+        it('should handle checkZip errors', async function () {
+            const zipError = new Error('zip failed');
+            gscan.checkZip = vi.fn(() => Promise.reject(zipError));
+            await runCheck({zip: true, themePath: '/tmp/theme.zip'}, {});
+
+            // checkZip catch logs the error object directly, not err.message
+            expect(mockLog).toHaveBeenCalledWith(zipError);
+        });
+    });
+
+    describe('CLI binary (smoke test)', function () {
+        it('should boot, parse args, check a theme, and exit', function () {
+            const cliBin = path.resolve(__dirname, '../bin/cli.js');
+            const fixture = path.resolve(__dirname, 'fixtures/themes/020-structure/mixed');
+            let result;
+            try {
+                const stdout = execFileSync(process.execPath, [cliBin, fixture, '--v6'], {
+                    encoding: 'utf8',
+                    timeout: 10000,
+                    env: {...process.env, NO_COLOR: '1'}
+                });
+                result = {exitCode: 0, stdout};
+            } catch (err) {
+                result = {exitCode: err.status, stdout: err.stdout || ''};
+            }
+
+            expect(result.exitCode).toBe(1); // fixture has errors
+            // Normalize the dash separator line which varies with chalk's ANSI output
+            const normalized = stripAnsi(result.stdout).replace(/-{2,}/g, '---');
+            expect(normalized).toMatchSnapshot();
+        });
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,7 +14,7 @@ module.exports = defineConfig({
         },
         coverage: {
             provider: 'v8',
-            include: ['lib/**/*.js'],
+            include: ['lib/**/*.js', 'bin/**/*.js'],
             exclude: ['lib/faker/**'],
             reporter: ['html', 'text-summary'],
             thresholds: {


### PR DESCRIPTION
closes https://github.com/TryGhost/gscan/issues/717

- we had no tests for the CLI, this adds them
- these tests would have caught https://github.com/TryGhost/gscan/issues/710 before it happened
- originally i wanted to add the tests with no changes to `cli.js`, but it wasn't structured in such a way that would make that easy, and code coverage would have been an issue. so this breaks some of the logic out into smaller functions
- also wraps CLI execution in a `require.main === module` guard so the file can be imported as a module without triggering argument parsing
- includes a test that actually runs the cli and verifies a snapshot
- this PR should have no impact on gscan cli usage
- a follow up PR will clean up cli.js further