### PR TITLE
Removed app from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "files": [
     "lib",
-    "bin",
-    "app"
+    "bin"
   ]
 }


### PR DESCRIPTION
ref https://github.com/TryGhost/gscan/issues/730

- when users do something like `npm i gscan`, they're currently including the files for the web app at gscan.ghost.org when they do that
- this removes `app` from the files list, so now when things are packaged up for npm it only includes `lib` and `bin`
- this should have no impact on the web app
- this should significantly improve gscan's package size. `npm pack --dry-run` shows the following:

|        | Package size | Unpacked size |
|--------|-------------|---------------|
| Before | 596.8 kB    | 950.5 kB      |
| After  | 56.0 kB     | 320.5 kB      |
