### PR TITLE
Added missing knownHelpers for Ghost v6 helpers

### DIFF
--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -8,7 +8,7 @@ const previousTemplates = previousSpec.templates;
 const previousRules = previousSpec.rules;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = ['split'];
+let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search'];
 let templates = [];
 let rules = {
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': {


### PR DESCRIPTION
## Summary

- Added `json`, `color_to_rgba`, `contrast_text_color` to v6 knownHelpers — new helpers introduced in Ghost's private page feature ([Ghost PR #26762](https://github.com/TryGhost/Ghost/pull/26762))
- Added `raw` and `search` — pre-existing Ghost helpers that were missing from gscan's knownHelpers

Without these, themes using any of these helpers get false "unknown helper" warnings during validation.

## Context

Ghost has a cross-reference test that verifies all theme-facing helpers in `core/frontend/helpers/` are present in gscan's `knownHelpers`. That test currently fails for these 5 helpers, blocking merge until this gscan update lands.