### PR TITLE
Added offer_duration to knownHelpers

### DIFF
--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -8,7 +8,7 @@ const previousTemplates = previousSpec.templates;
 const previousRules = previousSpec.rules;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search'];
+let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search', 'offer_duration'];
 let templates = [];
 let rules = {
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3462/register-offer-duration-helper-in-gscan

Added `offer_duration` to the v6 spec's `knownHelpers` so themes using the new `{{offer_duration}}` helper won't trigger a GS120 unknown helper warning.

This helper is being added to Ghost core as part of the theme helpers for account pages project — it outputs the duration context of an active subscription discount ("Forever", "Ends 2 May 2026").