### PR TITLE
Add AI tooling config to ignored paths

### DIFF
--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -11,6 +11,9 @@ const ignore = [
     '.DS_Store',
     '.git',
     '.svn',
+    '.claude',
+    'CLAUDE.md',
+    'AGENTS.md',
     'Thumbs.db',
     '.yarn-cache'
 ];

--- a/test/fixtures/themes/theme-with-ai-tooling/.claude/settings.json
+++ b/test/fixtures/themes/theme-with-ai-tooling/.claude/settings.json
@@ -1,0 +1,1 @@
+{"permissions": {}}

--- a/test/fixtures/themes/theme-with-ai-tooling/.claude/settings.symlink.json
+++ b/test/fixtures/themes/theme-with-ai-tooling/.claude/settings.symlink.json
@@ -1,0 +1,1 @@
+settings.json

--- a/test/fixtures/themes/theme-with-ai-tooling/AGENTS.md
+++ b/test/fixtures/themes/theme-with-ai-tooling/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+This file must be ignored by gscan.

--- a/test/fixtures/themes/theme-with-ai-tooling/CLAUDE.md
+++ b/test/fixtures/themes/theme-with-ai-tooling/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude project instructions
+
+This file must be ignored by gscan.

--- a/test/fixtures/themes/theme-with-ai-tooling/index.hbs
+++ b/test/fixtures/themes/theme-with-ai-tooling/index.hbs
@@ -1,0 +1,1 @@
+{{!-- minimal index template --}}

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -193,4 +193,20 @@ describe('Read theme', function () {
 
         expect(theme.customSettings).toEqual({});
     });
+
+    it('ignores AI tooling files and dirs (.claude, CLAUDE.md, AGENTS.md)', async function () {
+        // Regression for PR #796: a symlink under `.claude/` previously
+        // surfaced in theme.files and triggered a fatal GS030-ASSET-SYM.
+        // The fixture intentionally includes a symlink inside `.claude/`.
+        const theme = await readTheme(themePath('theme-with-ai-tooling'));
+        utils.assertValidThemeObject(theme);
+
+        const filePaths = theme.files.map(f => f.file);
+
+        expect(filePaths).toEqual(['index.hbs']);
+        expect(filePaths).not.toContain('CLAUDE.md');
+        expect(filePaths).not.toContain('AGENTS.md');
+        expect(filePaths.some(p => p.startsWith('.claude'))).toBe(false);
+        expect(theme.files.some(f => f.symlink)).toBe(false);
+    });
 });


### PR DESCRIPTION
Adds `.claude/`, `CLAUDE.md`, and `AGENTS.md` to the ignore list in `read-theme.js`.

These are configuration files for AI coding tools (Claude Code, Codex, etc.) that increasingly appear in theme repos. Like `.git` and `.svn`, they are tooling artifacts that should not be validated as theme files.

Currently, a symlinked config file in `.claude/` triggers a fatal `GS030-ASSET-SYM` error when scanning a local theme directory, even though these files are never included in theme zip uploads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands the theme file ignore list, affecting which paths are skipped/removed during scanning without changing validation logic.
> 
> **Overview**
> Theme scanning now **skips AI tooling artifacts** by adding `.claude/`, `CLAUDE.md`, and `AGENTS.md` to the ignored paths in `lib/read-theme.js`, preventing these files from being processed (and, when scanning extracted zips in temp dirs, from triggering errors like symlink checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8378fcff686dea50b1a813bf5bcc6c8198508603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->