### PR TITLE
Added social_accounts to v6 knownHelpers

### DIFF
--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -8,7 +8,7 @@ const previousTemplates = previousSpec.templates;
 const previousRules = previousSpec.rules;
 
 // assign new or overwrite existing knownHelpers, templates, or rules here:
-let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search'];
+let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search', 'social_accounts'];
 let templates = [];
 let rules = {
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': {


### PR DESCRIPTION
## Summary

Adds `social_accounts` to v6 `knownHelpers` so themes using the new helper don't trip Handlebars' unknown-helper validation.

The helper is a block iterator over a site's or author's connected social accounts. It replaces the ~27 lines of repetitive `{{#if twitter}}…{{#if facebook}}…` blocks themes currently need to render a row of social icons. Per-iteration it exposes `{type, href, username, name}` so themes keep full control of markup.

```hbs
{{#social_accounts @site}}
    <a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
        {{> (concat "icons/" type)}}
    </a>
{{/social_accounts}}
```

Companion PR: TryGhost/Ghost#27834

## Test plan

- [x] `yarn test` — 403 passing, no regressions
- [x] `yarn lint` — clean

Matches the precedent set by #742 (Added missing knownHelpers for Ghost v6 helpers).
