### PR TITLE
Pass zip limits through gscan

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -32,6 +32,7 @@ function loadChecks() {
  * @param {string} [options.themeName] name of the checked theme
  * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
  * @param {boolean} [options.skipChecks] flag to allow reading theme without incurring check costs
+ * @param {Object=} [options.limits] zip extraction size limits
  * @returns {Promise<Object>}
  */
 const check = async function checkAll(themePath, options = {}) {
@@ -105,7 +106,7 @@ const checkZip = async function checkZip(path, options) {
 
     try {
         const readZip = require('./read-zip');
-        ({path: extractedZipPath} = await readZip(zip));
+        ({path: extractedZipPath} = await readZip(zip, {limits: options.limits}));
         return await check(extractedZipPath, Object.assign({themeName: zip.name}, options));
     } catch (error) {
         if (!errors.utils.isGhostError(error)) {

--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -7,6 +7,10 @@ const {extract} = require('@tryghost/zip');
 const errors = require('@tryghost/errors');
 const _ = require('lodash');
 
+const isKnownZipError = (err) => {
+    return errors.utils.isGhostError(err);
+};
+
 const resolveBaseDir = async (zipPath) => {
     let matches = [];
 
@@ -25,12 +29,17 @@ const resolveBaseDir = async (zipPath) => {
     return zipPath;
 };
 
-const readZip = (zip) => {
+const readZip = (zip, options = {}) => {
     const tempUuid = randomUUID();
     const tempPath = os.tmpdir() + '/' + tempUuid;
+    const extractOptions = {};
+
+    if (options.limits) {
+        extractOptions.limits = options.limits;
+    }
 
     debug('Reading Zip', zip.path, 'into', tempPath);
-    return extract(zip.path, tempPath)
+    return extract(zip.path, tempPath, extractOptions)
         .then(async () => {
             let resolvedPath = await resolveBaseDir(tempPath);
             zip.origPath = tempPath;
@@ -40,6 +49,10 @@ const readZip = (zip) => {
             return zip;
         }).catch((err) => {
             debug('Zip extraction error', err);
+
+            if (isKnownZipError(err)) {
+                throw err;
+            }
 
             throw new errors.ValidationError({
                 message: 'Failed to read zip file',

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -141,5 +141,39 @@ describe('Check zip', function () {
 
             await fs.rm(theme.path, {recursive: true, force: true});
         });
+
+        it('passes limits to readZip', async function () {
+            const readZipPath = require.resolve('../lib/read-zip');
+            const originalReadZip = require(readZipPath);
+            const limits = {
+                perEntryUncompressedBytes: 100,
+                totalUncompressedBytes: 200
+            };
+            const zip = {
+                path: themePath('example.zip'),
+                name: 'example.zip'
+            };
+            const readZip = vi.fn(async () => {
+                return {
+                    path: themePath('is-empty'),
+                    name: 'example.zip'
+                };
+            });
+
+            require.cache[readZipPath].exports = readZip;
+
+            try {
+                await checkZip(zip, {
+                    limits,
+                    skipChecks: true,
+                    checkVersion: 'v5',
+                    keepExtractedDir: true
+                });
+
+                expect(readZip).toHaveBeenCalledWith(zip, {limits});
+            } finally {
+                require.cache[readZipPath].exports = originalReadZip;
+            }
+        });
     });
 });

--- a/test/read-zip.test.js
+++ b/test/read-zip.test.js
@@ -1,7 +1,26 @@
 const fs = require('fs/promises');
+const errors = require('@tryghost/errors');
 const utils = require('./utils');
 const readZip = require('../lib/read-zip');
 const themePath = utils.themePath;
+
+function loadReadZipWithExtract(extract) {
+    const zipModulePath = require.resolve('@tryghost/zip');
+    const readZipModulePath = require.resolve('../lib/read-zip');
+    const originalZipExports = require.cache[zipModulePath].exports;
+
+    delete require.cache[readZipModulePath];
+    require.cache[zipModulePath].exports = {extract};
+
+    return {
+        readZip: require('../lib/read-zip'),
+        restore() {
+            require.cache[zipModulePath].exports = originalZipExports;
+            delete require.cache[readZipModulePath];
+            require('../lib/read-zip');
+        }
+    };
+}
 
 /**
  * Response object from .check is:
@@ -105,5 +124,95 @@ describe('Zip file handler can read zip files', function () {
                 expect(zip.path).toEqual(zip.origPath);
                 expect(zip.origName).toEqual('not-a-theme');
             });
+    });
+
+    it('passes configured limits to zip extraction', async function () {
+        const limits = {
+            perEntryUncompressedBytes: 100,
+            totalUncompressedBytes: 200
+        };
+        const extract = vi.fn(async (zipPath, tempPath) => {
+            await fs.mkdir(tempPath, {recursive: true});
+        });
+        const mocked = loadReadZipWithExtract(extract);
+
+        try {
+            const zip = await mocked.readZip({path: '/tmp/theme.zip', name: 'theme.zip'}, {limits});
+            tempDirs.push(zip.origPath);
+
+            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {limits});
+        } finally {
+            mocked.restore();
+        }
+    });
+
+    it('wraps extraction errors when limits are not configured', async function () {
+        const extractError = new Error('invalid zip file');
+        const extract = vi.fn(async () => {
+            throw extractError;
+        });
+        const mocked = loadReadZipWithExtract(extract);
+
+        try {
+            await expect(mocked.readZip({path: '/tmp/theme.zip', name: 'theme.zip'})).rejects.toMatchObject({
+                errorType: 'ValidationError',
+                message: 'Failed to read zip file',
+                help: 'Your zip file might be corrupted, try unzipping and zipping again.',
+                context: 'theme.zip',
+                errorDetails: extractError.message
+            });
+
+            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {});
+        } finally {
+            mocked.restore();
+        }
+    });
+
+    it('preserves zip GhostErrors from extraction', async function () {
+        const zipError = new errors.UnsupportedMediaTypeError({
+            message: 'Zip entry exceeds maximum uncompressed size.',
+            context: 'The zip contains an entry that exceeds the maximum uncompressed size.',
+            code: 'ENTRY_TOO_LARGE',
+            errorDetails: {
+                entryName: 'big-file.txt',
+                observedBytes: 101,
+                limitBytes: 100
+            }
+        });
+        const extract = vi.fn(async () => {
+            throw zipError;
+        });
+        const mocked = loadReadZipWithExtract(extract);
+
+        try {
+            await expect(mocked.readZip({path: '/tmp/theme.zip', name: 'theme.zip'}, {
+                limits: {
+                    perEntryUncompressedBytes: 100
+                }
+            })).rejects.toBe(zipError);
+        } finally {
+            mocked.restore();
+        }
+    });
+
+    it('preserves zip symlink errors from extraction', async function () {
+        const zipError = new errors.UnsupportedMediaTypeError({
+            message: 'Symlinks are not allowed in the zip folder.',
+            context: 'The zip contains a symlink entry.',
+            code: 'SYMLINK_NOT_ALLOWED',
+            errorDetails: {
+                entryName: 'themes/test-target'
+            }
+        });
+        const extract = vi.fn(async () => {
+            throw zipError;
+        });
+        const mocked = loadReadZipWithExtract(extract);
+
+        try {
+            await expect(mocked.readZip({path: '/tmp/theme.zip', name: 'theme.zip'})).rejects.toBe(zipError);
+        } finally {
+            mocked.restore();
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Thread optional zip extraction limits from `checkZip` into `readZip` and `@tryghost/zip.extract`.
- Preserve zip limit/configuration errors from `@tryghost/zip` so callers can handle them directly.
- Cover limits passthrough, no-limit wrapping behavior, and preserved zip limit errors in tests.

## Testing
- `yarn test`