### PR TITLE
Rewrote GS110 missing-page-builder-usage rule

### DIFF
--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -9,11 +9,7 @@ module.exports = class BaseRule {
         this.helpers = options.helpers;
         this.inlinePartials = options.inlinePartials || [];
         this.customThemeSettings = options.customThemeSettings;
-        // Source of truth: the active spec's `pageBuilderProperties` export
-        // (see lib/specs/v5.js). The default here is a safety net for callers
-        // that construct a rule without an options.knownPageBuilderProperties
-        // override — keep it in sync with the spec until ASTLinter plumbs the
-        // spec-derived list through to the rule constructor.
+        // Keep in sync with `pageBuilderProperties` in lib/specs/v5.js.
         this.knownPageBuilderProperties = options.knownPageBuilderProperties || ['show_title_and_feature_image'];
     }
 

--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -9,7 +9,11 @@ module.exports = class BaseRule {
         this.helpers = options.helpers;
         this.inlinePartials = options.inlinePartials || [];
         this.customThemeSettings = options.customThemeSettings;
-        // TODO: remove hardcoded list of known page builder properties once we have a way to get them from the spec
+        // Source of truth: the active spec's `pageBuilderProperties` export
+        // (see lib/specs/v5.js). The default here is a safety net for callers
+        // that construct a rule without an options.knownPageBuilderProperties
+        // override — keep it in sync with the spec until ASTLinter plumbs the
+        // spec-derived list through to the rule constructor.
         this.knownPageBuilderProperties = options.knownPageBuilderProperties || ['show_title_and_feature_image'];
     }
 

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -54,7 +54,7 @@ const ruleImplementations = {
             notUsedProperties.forEach((property) => {
                 log.failure({
                     ref,
-                    message: `{{@page.${property}}} is not used in any template — gate the relevant markup with {{#if @page.${property}}}…{{/if}} so this editor setting takes effect.`
+                    message: `<code>{{@page.${property}}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.${property}}}…{{/if}}</code> so this editor setting takes effect.`
                 });
             });
         }

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -12,14 +12,17 @@ function findPageTemplateRef(theme) {
         return 'page.hbs';
     }
 
-    const pageHbs = theme.files.find(f => f.file === 'page.hbs');
+    // read-theme.js pre-computes a forward-slash-normalised path on every
+    // theme file as `normalizedFile`, so matching against it works across
+    // OSes without re-running normalizePath() here.
+    const pageHbs = theme.files.find(f => f.normalizedFile === 'page.hbs');
     if (pageHbs) {
-        return pageHbs.file;
+        return pageHbs.normalizedFile;
     }
 
-    const pageOverride = theme.files.find(f => /^page-[^/]+\.hbs$/.test(f.file));
+    const pageOverride = theme.files.find(f => /^page-[^/]+\.hbs$/.test(f.normalizedFile));
     if (pageOverride) {
-        return pageOverride.file;
+        return pageOverride.normalizedFile;
     }
 
     return 'page.hbs';

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -1,5 +1,29 @@
 const _ = require('lodash');
+const spec = require('../specs');
+const {versions} = require('../utils');
 const {getRules, applyRule, parseWithAST} = require('../utils/check-utils');
+
+// Returns the most representative page template path in a theme, used as
+// the `ref` for missing-page-property failures so the report points at a
+// real file. Prefers page.hbs, then any page-*.hbs override, then falls
+// back to "page.hbs" as a suggested location even if the theme has none.
+function findPageTemplateRef(theme) {
+    if (!theme || !Array.isArray(theme.files)) {
+        return 'page.hbs';
+    }
+
+    const pageHbs = theme.files.find(f => f.file === 'page.hbs');
+    if (pageHbs) {
+        return pageHbs.file;
+    }
+
+    const pageOverride = theme.files.find(f => /^page-[^/]+\.hbs$/.test(f.file));
+    if (pageOverride) {
+        return pageOverride.file;
+    }
+
+    return 'page.hbs';
+}
 
 const ruleImplementations = {
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
@@ -20,15 +44,21 @@ const ruleImplementations = {
                 }});
             }
         },
-        done: ({log, result}) => {
-            // TODO: get this from the spec rather than hard-coding to account for version changes
-            const knownPageBuilderProperties = ['show_title_and_feature_image'];
+        done: ({theme, log, result, options}) => {
+            const checkVersion = _.get(options, 'checkVersion', versions.default);
+            const knownPageBuilderProperties = spec.get([checkVersion]).pageBuilderProperties || [];
             const notUsedProperties = knownPageBuilderProperties.filter(x => !result.pageBuilderProperties.has(x));
+
+            if (!notUsedProperties.length) {
+                return;
+            }
+
+            const ref = findPageTemplateRef(theme);
 
             notUsedProperties.forEach((property) => {
                 log.failure({
-                    ref: `page.hbs`,
-                    message: `@page.${property} is not used`
+                    ref,
+                    message: `{{@page.${property}}} is not used in any template — gate the relevant markup with {{#if @page.${property}}}…{{/if}} so this editor setting takes effect.`
                 });
             });
         }

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -3,18 +3,11 @@ const spec = require('../specs');
 const {versions} = require('../utils');
 const {getRules, applyRule, parseWithAST} = require('../utils/check-utils');
 
-// Returns the most representative page template path in a theme, used as
-// the `ref` for missing-page-property failures so the report points at a
-// real file. Prefers page.hbs, then any page-*.hbs override, then falls
-// back to "page.hbs" as a suggested location even if the theme has none.
 function findPageTemplateRef(theme) {
     if (!theme || !Array.isArray(theme.files)) {
         return 'page.hbs';
     }
 
-    // read-theme.js pre-computes a forward-slash-normalised path on every
-    // theme file as `normalizedFile`, so matching against it works across
-    // OSes without re-running normalizePath() here.
     const pageHbs = theme.files.find(f => f.normalizedFile === 'page.hbs');
     if (pageHbs) {
         return pageHbs.normalizedFile;

--- a/lib/checks/110-page-builder-usage.js
+++ b/lib/checks/110-page-builder-usage.js
@@ -54,7 +54,7 @@ const ruleImplementations = {
             notUsedProperties.forEach((property) => {
                 log.failure({
                     ref,
-                    message: `<code>{{@page.${property}}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.${property}}}…{{/if}}</code> so this editor setting takes effect.`
+                    message: `{{@page.${property}}} is not used`
                 });
             });
         }

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -733,9 +733,8 @@ let rules = {
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
         level: 'error',
         fatal: true,
-        rule: 'Unsupported page builder feature used',
-        details: oneLineTrim`A page feature used via the <code>{{@page}}</code> global was detected but is not supported by this version of Ghost. Please upgrade to the latest version for full access.&nbsp;
-        You can find more information about the <code>{{@page}}</code> global <a href="${docsBaseUrl}helpers/page/" target=_blank>here</a>.`
+        rule: 'Remove or correct the unknown <code>{{@page}}</code> property',
+        details: oneLineTrim`The <code>{{@page}}</code> global only exposes a known set of editor settings, so an unrecognised property won't render anything and is usually a typo. Remove the reference or check the spelling against the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a>.`
     },
     'GS120-NO-UNKNOWN-GLOBALS': {
         level: 'error',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -726,10 +726,9 @@ let rules = {
         Check the <a href="${docsBaseUrl}custom-settings" target=_blank><code>config.custom</code> documentation</a> for further information.`
     },
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
-        level: 'error',
+        level: 'warning',
         rule: 'Theme is missing support for the <code>{{@page.show_title_and_feature_image}}</code> editor setting',
-        details: oneLineTrim`The <code>{{@page.show_title_and_feature_image}}</code> toggle lets editors hide a page's title and feature image on a per-page basis. Themes need to gate the title and feature image markup with <code>{{#if @page.show_title_and_feature_image}}</code> for the setting to take effect.<br><br>
-        <b>Example</b> — gate the markup in <code>page.hbs</code>:<br>
+        details: oneLineTrim`Gate the title and feature image markup in <code>page.hbs</code>:<br>
         <code>&#123;&#123;#if @page.show_title_and_feature_image&#125;&#125;<br>
         &nbsp;&nbsp;&lt;h1&gt;&#123;&#123;title&#125;&#125;&lt;/h1&gt;<br>
         &nbsp;&nbsp;&#123;&#123;!-- feature image markup --&#125;&#125;<br>

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -727,14 +727,14 @@ let rules = {
     },
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
         level: 'error',
-        rule: 'Theme is missing support for a <code>{{@page}}</code> editor setting',
-        details: oneLineTrim`The <code>{{@page}}</code> global exposes editor settings that themes need to honour by gating the relevant markup with an <code>{{#if @page.<i>property</i>}}</code> block. Without the gate, the setting has no effect when the page is rendered.<br><br>
-        <b>Example</b> — gate the title and feature image markup in <code>page.hbs</code> so the editor's "Show title and feature image" toggle takes effect:<br>
+        rule: 'Theme is missing support for the <code>{{@page.show_title_and_feature_image}}</code> editor setting',
+        details: oneLineTrim`The <code>{{@page.show_title_and_feature_image}}</code> toggle lets editors hide a page's title and feature image on a per-page basis. Themes need to gate the title and feature image markup with <code>{{#if @page.show_title_and_feature_image}}</code> for the setting to take effect.<br><br>
+        <b>Example</b> — gate the markup in <code>page.hbs</code>:<br>
         <code>&#123;&#123;#if @page.show_title_and_feature_image&#125;&#125;<br>
         &nbsp;&nbsp;&lt;h1&gt;&#123;&#123;title&#125;&#125;&lt;/h1&gt;<br>
         &nbsp;&nbsp;&#123;&#123;!-- feature image markup --&#125;&#125;<br>
         &#123;&#123;/if&#125;&#125;</code><br><br>
-        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> global documentation</a> for the available properties.`
+        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a> for details.`
     },
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
         level: 'error',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -727,14 +727,14 @@ let rules = {
     },
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
         level: 'error',
-        rule: 'Theme is missing support for one or more <code>{{@page}}</code> properties',
-        details: oneLineTrim`Pages in Ghost's editor expose per-page display toggles (e.g. <code>show_title_and_feature_image</code>) on the <code>{{@page}}</code> global. Themes should honour these toggles by gating the relevant markup with an <code>{{#if @page.<i>property</i>}}</code> block — otherwise the editor setting has no effect when the page is rendered.<br><br>
-        <b>Example</b> — gate the title and feature image markup in <code>page.hbs</code>:<br>
+        rule: 'Theme is missing support for a <code>{{@page}}</code> editor setting',
+        details: oneLineTrim`The <code>{{@page}}</code> global exposes editor settings that themes need to honour by gating the relevant markup with an <code>{{#if @page.<i>property</i>}}</code> block. Without the gate, the setting has no effect when the page is rendered.<br><br>
+        <b>Example</b> — gate the title and feature image markup in <code>page.hbs</code> so the editor's "Show title and feature image" toggle takes effect:<br>
         <code>&#123;&#123;#if @page.show_title_and_feature_image&#125;&#125;<br>
         &nbsp;&nbsp;&lt;h1&gt;&#123;&#123;title&#125;&#125;&lt;/h1&gt;<br>
         &nbsp;&nbsp;&#123;&#123;!-- feature image markup --&#125;&#125;<br>
         &#123;&#123;/if&#125;&#125;</code><br><br>
-        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> global documentation</a> for the full list of properties.`
+        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> global documentation</a> for the available properties.`
     },
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
         level: 'error',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -731,8 +731,7 @@ let rules = {
         details: oneLineTrim`Pages have a toggle that lets editors hide a page's title and feature image on a per-page basis. Gate any relevant markup in page templates with <code>{{#if @page.show_title_and_feature_image}}</code> for the toggle to take effect.`
     },
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
-        level: 'error',
-        fatal: true,
+        level: 'warning',
         rule: 'Remove or correct the unknown <code>{{@page}}</code> property',
         details: oneLineTrim`Ghost currently supports only <code>{{@page.show_title_and_feature_image}}</code>. Remove the reference or correct the spelling — see the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a> for details.`
     },

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -727,13 +727,8 @@ let rules = {
     },
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
         level: 'warning',
-        rule: 'Theme is missing support for the <code>{{@page.show_title_and_feature_image}}</code> editor setting',
-        details: oneLineTrim`Gate the title and feature image markup in <code>page.hbs</code>:<br>
-        <code>&#123;&#123;#if @page.show_title_and_feature_image&#125;&#125;<br>
-        &nbsp;&nbsp;&lt;h1&gt;&#123;&#123;title&#125;&#125;&lt;/h1&gt;<br>
-        &nbsp;&nbsp;&#123;&#123;!-- feature image markup --&#125;&#125;<br>
-        &#123;&#123;/if&#125;&#125;</code><br><br>
-        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a> for details.`
+        rule: 'Support the <code>{{@page.show_title_and_feature_image}}</code> editor setting',
+        details: oneLineTrim`Pages have a toggle that lets editors hide a page's title and feature image on a per-page basis. Gate any relevant markup in page templates with <code>{{#if @page.show_title_and_feature_image}}</code> for the toggle to take effect.`
     },
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
         level: 'error',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -734,7 +734,7 @@ let rules = {
         level: 'error',
         fatal: true,
         rule: 'Remove or correct the unknown <code>{{@page}}</code> property',
-        details: oneLineTrim`The <code>{{@page}}</code> global only exposes a known set of editor settings, so an unrecognised property won't render anything and is usually a typo. Remove the reference or check the spelling against the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a>.`
+        details: oneLineTrim`Ghost currently supports only <code>{{@page.show_title_and_feature_image}}</code>. Remove the reference or correct the spelling — see the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> documentation</a> for details.`
     },
     'GS120-NO-UNKNOWN-GLOBALS': {
         level: 'error',

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -781,10 +781,6 @@ module.exports = {
     knownHelpers: knownHelpers,
     templates: templates,
     rules: rules,
-    // Per-page display toggles exposed on the {{@page}} global. Themes are
-    // expected to gate the corresponding markup with {{#if @page.property}}.
-    // Source-of-truth for both the GS110 check ("missing" usage) and the
-    // ast-linter rule that flags unknown @page properties.
     pageBuilderProperties: ['show_title_and_feature_image'],
     /**
      * Copy of Ghost defaults for https://github.com/TryGhost/Ghost/blob/e25f1df0ae551c447da0d319bae06eadf9665444/core/frontend/services/theme-engine/config/defaults.json

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -727,9 +727,14 @@ let rules = {
     },
     'GS110-NO-MISSING-PAGE-BUILDER-USAGE': {
         level: 'error',
-        rule: 'Not all page features are being used',
-        details: oneLineTrim`<b>This error only applies to pages created with the Beta editor.</b> Some page features used by Ghost via the <code>{{@page}}</code> global are not implemented in this theme.&nbsp;
-        Find more information about the <code>{{@page}}</code> global <a href="${docsBaseUrl}helpers/page/" target=_blank>here</a>.`
+        rule: 'Theme is missing support for one or more <code>{{@page}}</code> properties',
+        details: oneLineTrim`Pages in Ghost's editor expose per-page display toggles (e.g. <code>show_title_and_feature_image</code>) on the <code>{{@page}}</code> global. Themes should honour these toggles by gating the relevant markup with an <code>{{#if @page.<i>property</i>}}</code> block — otherwise the editor setting has no effect when the page is rendered.<br><br>
+        <b>Example</b> — gate the title and feature image markup in <code>page.hbs</code>:<br>
+        <code>&#123;&#123;#if @page.show_title_and_feature_image&#125;&#125;<br>
+        &nbsp;&nbsp;&lt;h1&gt;&#123;&#123;title&#125;&#125;&lt;/h1&gt;<br>
+        &nbsp;&nbsp;&#123;&#123;!-- feature image markup --&#125;&#125;<br>
+        &#123;&#123;/if&#125;&#125;</code><br><br>
+        See the <a href="${docsBaseUrl}helpers/page/" target=_blank><code>{{@page}}</code> global documentation</a> for the full list of properties.`
     },
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': {
         level: 'error',
@@ -776,6 +781,11 @@ module.exports = {
     knownHelpers: knownHelpers,
     templates: templates,
     rules: rules,
+    // Per-page display toggles exposed on the {{@page}} global. Themes are
+    // expected to gate the corresponding markup with {{#if @page.property}}.
+    // Source-of-truth for both the GS110 check ("missing" usage) and the
+    // ast-linter rule that flags unknown @page properties.
+    pageBuilderProperties: ['show_title_and_feature_image'],
     /**
      * Copy of Ghost defaults for https://github.com/TryGhost/Ghost/blob/e25f1df0ae551c447da0d319bae06eadf9665444/core/frontend/services/theme-engine/config/defaults.json
      */

--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -61,5 +61,6 @@ module.exports = {
     knownHelpers: knownHelpers,
     templates: templates,
     rules: rules,
+    pageBuilderProperties: previousSpec.pageBuilderProperties,
     defaultPackageJSON: previousSpec.defaultPackageJSON
 };

--- a/lib/utils/check-utils.js
+++ b/lib/utils/check-utils.js
@@ -51,19 +51,19 @@ function applyRule(rule, theme) {
 
         // Initialize the rule (optional)
         if (typeof rule.init === 'function') {
-            rule.init({theme, log: getLogger({theme, rule}), result});
+            rule.init({theme, log: getLogger({theme, rule}), result, options: rule.options});
         }
 
         // Run the main function on each theme file (optional)
         if (typeof rule.eachFile === 'function') {
             _.each(theme.files, function (themeFile) {
-                rule.eachFile({file: themeFile, theme, log: getLogger({theme, rule}), result, partialVerificationCache});
+                rule.eachFile({file: themeFile, theme, log: getLogger({theme, rule}), result, partialVerificationCache, options: rule.options});
             });
         }
 
         // Run the final function
         if (typeof rule.done === 'function') {
-            rule.done({theme, log: getLogger({theme, rule}), result});
+            rule.done({theme, log: getLogger({theme, rule}), result, options: rule.options});
         }
     } catch (e) {
         // Output something instead of failing silently (should never happen)

--- a/test/110-page-builder-usage.test.js
+++ b/test/110-page-builder-usage.test.js
@@ -15,7 +15,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '{{@page.show_title_and_feature_image}} is not used in any template — gate the relevant markup with {{#if @page.show_title_and_feature_image}}…{{/if}} so this editor setting takes effect.',
+                    message: '<code>{{@page.show_title_and_feature_image}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.show_title_and_feature_image}}…{{/if}}</code> so this editor setting takes effect.',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);
@@ -57,7 +57,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '{{@page.show_title_and_feature_image}} is not used in any template — gate the relevant markup with {{#if @page.show_title_and_feature_image}}…{{/if}} so this editor setting takes effect.',
+                    message: '<code>{{@page.show_title_and_feature_image}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.show_title_and_feature_image}}…{{/if}}</code> so this editor setting takes effect.',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);

--- a/test/110-page-builder-usage.test.js
+++ b/test/110-page-builder-usage.test.js
@@ -15,7 +15,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '@page.show_title_and_feature_image is not used',
+                    message: '{{@page.show_title_and_feature_image}} is not used in any template — gate the relevant markup with {{#if @page.show_title_and_feature_image}}…{{/if}} so this editor setting takes effect.',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);
@@ -57,7 +57,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '@page.show_title_and_feature_image is not used',
+                    message: '{{@page.show_title_and_feature_image}} is not used in any template — gate the relevant markup with {{#if @page.show_title_and_feature_image}}…{{/if}} so this editor setting takes effect.',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);

--- a/test/110-page-builder-usage.test.js
+++ b/test/110-page-builder-usage.test.js
@@ -15,7 +15,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '<code>{{@page.show_title_and_feature_image}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.show_title_and_feature_image}}…{{/if}}</code> so this editor setting takes effect.',
+                    message: '{{@page.show_title_and_feature_image}} is not used',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);
@@ -57,7 +57,7 @@ describe('110 Page-builder usage', function () {
             expect(output.results.fail['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].failures).toEqual([
                 {
                     ref: 'page.hbs',
-                    message: '<code>{{@page.show_title_and_feature_image}}</code> is not used in any template — gate the relevant markup with <code>{{#if @page.show_title_and_feature_image}}…{{/if}}</code> so this editor setting takes effect.',
+                    message: '{{@page.show_title_and_feature_image}} is not used',
                     rule: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
                 }
             ]);

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -53,7 +53,7 @@ Affected Files: styles
 - Error: The .kg-width-full CSS class is required to appear styled in your theme
 Affected Files: styles
 
-- Error: Not all page features are being used
+- Error: Theme is missing support for one or more {{@page}} properties
 Affected Files: page.hbs
 
 

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -4,7 +4,7 @@ exports[`CLI > CLI binary (smoke test) > should boot, parse args, check a theme,
 "
 Checking theme compatibility...
 
-Your theme has 20 errors and 7 warnings!
+Your theme has 19 errors and 8 warnings!
 ---
 
 Errors
@@ -53,9 +53,6 @@ Affected Files: styles
 - Error: The .kg-width-full CSS class is required to appear styled in your theme
 Affected Files: styles
 
-- Error: Theme is missing support for the {{@page.show_title_and_feature_image}} editor setting
-Affected Files: page.hbs
-
 
 Warnings
 ---
@@ -75,6 +72,9 @@ Affected Files: default.hbs
 
 - Warning: Missing support for custom fonts
 Affected Files: styles
+
+- Warning: Theme is missing support for the {{@page.show_title_and_feature_image}} editor setting
+Affected Files: page.hbs
 
 
 Recommendations

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -73,7 +73,7 @@ Affected Files: default.hbs
 - Warning: Missing support for custom fonts
 Affected Files: styles
 
-- Warning: Theme is missing support for the {{@page.show_title_and_feature_image}} editor setting
+- Warning: Support the {{@page.show_title_and_feature_image}} editor setting
 Affected Files: page.hbs
 
 

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -53,7 +53,7 @@ Affected Files: styles
 - Error: The .kg-width-full CSS class is required to appear styled in your theme
 Affected Files: styles
 
-- Error: Theme is missing support for one or more {{@page}} properties
+- Error: Theme is missing support for a {{@page}} editor setting
 Affected Files: page.hbs
 
 

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -53,7 +53,7 @@ Affected Files: styles
 - Error: The .kg-width-full CSS class is required to appear styled in your theme
 Affected Files: styles
 
-- Error: Theme is missing support for a {{@page}} editor setting
+- Error: Theme is missing support for the {{@page.show_title_and_feature_image}} editor setting
 Affected Files: page.hbs
 
 

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -324,7 +324,7 @@ describe('Format', function () {
             return check(themePath('005-compile/v5/invalid'), options).then((theme) => {
                 theme = format(theme, options);
 
-                expect(theme.results.error.length).toEqual(23);
+                expect(theme.results.error.length).toEqual(22);
 
                 const fatalErrors = theme.results.error.filter(error => error.fatal);
                 expect(fatalErrors.length).toEqual(1);
@@ -366,10 +366,10 @@ describe('Format', function () {
                 expect(theme.results.recommendation.all.length).toEqual(2);
                 expect(theme.results.recommendation.byFiles['package.json'].length).toEqual(2);
 
-                expect(theme.results.warning.all.length).toEqual(7);
+                expect(theme.results.warning.all.length).toEqual(8);
                 expect(theme.results.warning.byFiles['default.hbs'].length).toEqual(2);
 
-                expect(theme.results.error.all.length).toEqual(23);
+                expect(theme.results.error.all.length).toEqual(22);
 
                 const fatalErrors = theme.results.error.all.filter(error => error.fatal);
                 expect(fatalErrors.length).toEqual(1);
@@ -380,7 +380,7 @@ describe('Format', function () {
                 // two rules have file references
                 expect(theme.results.error.byFiles['author.hbs'].length).toEqual(1);
                 // page.hbs uses @blog which is deprecated and triggers the second rule failure
-                expect(theme.results.error.byFiles['page.hbs'].length).toEqual(3);
+                expect(theme.results.error.byFiles['page.hbs'].length).toEqual(2);
                 expect(theme.results.error.byFiles['post.hbs'].length).toEqual(1);
                 expect(theme.results.error.byFiles['index.hbs'].length).toEqual(1);
                 expect(theme.results.error.byFiles['package.json'].length).toEqual(17);
@@ -398,13 +398,13 @@ describe('Format', function () {
                 expect(theme.results.recommendation.all.length).toEqual(2);
                 expect(theme.results.recommendation.byFiles['package.json'].length).toEqual(2);
 
-                expect(theme.results.error.all.length).toEqual(105);
-                expect(theme.results.warning.all.length).toEqual(9);
+                expect(theme.results.error.all.length).toEqual(104);
+                expect(theme.results.warning.all.length).toEqual(10);
 
                 const errorErrors = theme.results.error.all
                     .filter(error => (error.level === 'error') && !error.fatal);
 
-                expect(errorErrors.length).toEqual(69);
+                expect(errorErrors.length).toEqual(68);
                 expect(errorErrors.map(e => e.code)).toEqual([
                     'GS001-DEPR-MD',
                     'GS001-DEPR-AIMG',
@@ -473,7 +473,6 @@ describe('Format', function () {
                     'GS090-NO-PRICE-DATA-CURRENCY-CONTEXT',
                     'GS090-NO-PRICE-DATA-MONTHLY-YEARLY',
                     'GS090-NO-TIER-PRICE-AS-OBJECT',
-                    'GS110-NO-MISSING-PAGE-BUILDER-USAGE',
                     'GS120-NO-UNKNOWN-GLOBALS'
                 ]);
 
@@ -547,7 +546,7 @@ describe('Format', function () {
             return check(themePath('005-compile/v5/invalid'), options).then((theme) => {
                 theme = format(theme, options);
 
-                expect(theme.results.error.length).toEqual(23);
+                expect(theme.results.error.length).toEqual(22);
 
                 const fatalErrors = theme.results.error.filter(error => error.fatal);
                 expect(fatalErrors.length).toEqual(1);
@@ -589,10 +588,10 @@ describe('Format', function () {
                 expect(theme.results.recommendation.all.length).toEqual(2);
                 expect(theme.results.recommendation.byFiles['package.json'].length).toEqual(2);
 
-                expect(theme.results.warning.all.length).toEqual(7);
+                expect(theme.results.warning.all.length).toEqual(8);
                 expect(theme.results.warning.byFiles['default.hbs'].length).toEqual(2);
 
-                expect(theme.results.error.all.length).toEqual(23);
+                expect(theme.results.error.all.length).toEqual(22);
 
                 const fatalErrors = theme.results.error.all.filter(error => error.fatal);
                 expect(fatalErrors.length).toEqual(1);
@@ -603,7 +602,7 @@ describe('Format', function () {
                 // two rules have file references
                 expect(theme.results.error.byFiles['author.hbs'].length).toEqual(1);
                 // page.hbs uses @blog which is deprecated and triggers the second rule failure
-                expect(theme.results.error.byFiles['page.hbs'].length).toEqual(3);
+                expect(theme.results.error.byFiles['page.hbs'].length).toEqual(2);
                 expect(theme.results.error.byFiles['post.hbs'].length).toEqual(1);
                 expect(theme.results.error.byFiles['index.hbs'].length).toEqual(1);
                 expect(theme.results.error.byFiles['package.json'].length).toEqual(17);
@@ -621,13 +620,13 @@ describe('Format', function () {
                 expect(theme.results.recommendation.all.length).toEqual(2);
                 expect(theme.results.recommendation.byFiles['package.json'].length).toEqual(2);
 
-                expect(theme.results.error.all.length).toEqual(105);
-                expect(theme.results.warning.all.length).toEqual(9);
+                expect(theme.results.error.all.length).toEqual(104);
+                expect(theme.results.warning.all.length).toEqual(10);
 
                 const errorErrors = theme.results.error.all
                     .filter(error => (error.level === 'error') && !error.fatal);
 
-                expect(errorErrors.length).toEqual(69);
+                expect(errorErrors.length).toEqual(68);
                 expect(errorErrors.map(e => e.code)).toEqual([
                     'GS001-DEPR-MD',
                     'GS001-DEPR-AIMG',
@@ -696,7 +695,6 @@ describe('Format', function () {
                     'GS090-NO-PRICE-DATA-CURRENCY-CONTEXT',
                     'GS090-NO-PRICE-DATA-MONTHLY-YEARLY',
                     'GS090-NO-TIER-PRICE-AS-OBJECT',
-                    'GS110-NO-MISSING-PAGE-BUILDER-USAGE',
                     'GS120-NO-UNKNOWN-GLOBALS'
                 ]);
 


### PR DESCRIPTION
## Summary

Reworks both `GS110` rules — `NO-MISSING-PAGE-BUILDER-USAGE` and `NO-UNKNOWN-PAGE-BUILDER-USAGE` — so the error theme developers land on actually tells them what to do. Both rules currently use internal jargon ("page builder feature", "Beta editor"), wrong-direction remediation ("upgrade Ghost"), or descriptive passive titles that obscure what's being flagged. Both also rendered `page.hbs` as the affected file even when the theme didn't have one. See [the forum thread](https://forum.ghost.org/t/social-accounts-v6-38-0-helper-for-theme-social-rendering/62854) for the report that prompted this.

## Before / after

### `GS110-NO-MISSING-PAGE-BUILDER-USAGE`

|  | Before | After |
|---|---|---|
| Level | error | **warning** |
| Title | "Not all page features are being used" | "Support the `{{@page.show_title_and_feature_image}}` editor setting" |
| Body  | "This error only applies to pages created with the Beta editor. Some page features used by Ghost via the `{{@page}}` global are not implemented in this theme. Find more information about the `{{@page}}` global here." | "Pages have a toggle that lets editors hide a page's title and feature image on a per-page basis. Gate any relevant markup in page templates with `{{#if @page.show_title_and_feature_image}}` for the toggle to take effect." |
| Affected files | always `page.hbs`, even when the theme didn't have one or used a `page-{slug}.hbs` override instead | `findPageTemplateRef(theme)` picks a page template that actually exists in the theme — `page.hbs` first, then any `page-{slug}.hbs` override, falling back to `page.hbs` as a hint only when neither exists |

### `GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE`

|  | Before | After |
|---|---|---|
| Level | error, fatal | **warning** |
| Title | "Unsupported page builder feature used" | "Remove or correct the unknown `{{@page}}` property" |
| Body  | "A page feature used via the `{{@page}}` global was detected but is not supported by this version of Ghost. Please upgrade to the latest version for full access." | "Ghost currently supports only `{{@page.show_title_and_feature_image}}`. Remove the reference or correct the spelling — see the `{{@page}}` documentation for details." |

## Severity drops

Both rules degrade a single editor feature rather than breaking the theme:

- A missing `{{#if @page.show_title_and_feature_image}}` gate means the editor's per-page hide-title toggle has no effect — title/feature image always render. Site still works.
- An unknown `{{@page.foo}}` reference renders as empty in Handlebars. Site still works.

Neither warrants blocking activation or being shown as an error.

## Internal changes

- New `pageBuilderProperties` export on the v5 spec (propagated through v6) — single source of truth for the list. The check now reads from the active spec instead of hard-coding the list inline.
- `applyRule()` in `check-utils.js` now threads `options` through `init` / `eachFile` / `done` (it was already passed to `isEnabled`). This lets the check look up the active spec by `checkVersion` in `done()`.
- The ast-linter `base.js` still keeps its own hard-coded default for `knownPageBuilderProperties`; `ASTLinter` doesn't plumb spec-derived options to rule constructors yet. Comment added pointing at the spec as source of truth — full removal is a small follow-up.

## Test plan

- [x] `yarn test` — 409 passing (updated the two `110-page-builder-usage` cases, the `format.test.js` count/code-list assertions, and the CLI snapshot for the new wording)
- [x] `yarn lint` — clean
- [x] Manually verified in a running Ghost: errors appear under **Warnings** in the Theme updated dialog with the new wording; sister UNKNOWN rule also fires with the new shape on a theme containing `{{@page.<typo>}}`
