### PR TITLE
Split the inline-dynamic-partial check into its own spec rule

### DIFF
--- a/lib/ast-linter/rules/lint-no-unknown-partials.js
+++ b/lib/ast-linter/rules/lint-no-unknown-partials.js
@@ -19,7 +19,8 @@ module.exports = class NoUnknownPartials extends Rule {
                     }
                     if (node.type === 'PartialStatement') {
                         return this.log({
-                            message: `Inlined dynamic partials like <code>{{> (dynamicPartial) }}</code> can result in page errors if the partial does not exist, use block dynamic partials instead.`,
+                            code: 'GS005-NO-INLINE-DYNAMIC-PARTIAL',
+                            message: `Inline dynamic partial used`,
                             ...logObject
                         });
                     }

--- a/lib/ast-linter/rules/lint-no-unknown-partials.js
+++ b/lib/ast-linter/rules/lint-no-unknown-partials.js
@@ -20,7 +20,7 @@ module.exports = class NoUnknownPartials extends Rule {
                     if (node.type === 'PartialStatement') {
                         return this.log({
                             code: 'GS005-NO-INLINE-DYNAMIC-PARTIAL',
-                            message: `Inline dynamic partial used`,
+                            message: `Inline dynamic partial on line ${logObject.line}: ${logObject.source}`,
                             ...logObject
                         });
                     }

--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -43,9 +43,11 @@ function processFileFunction(files, failures, theme, partialsFound) {
         });
 
         if (astResults.length) {
+            const first = astResults[0];
             failures.push({
                 ref: themeFile.file,
-                message: astResults[0].message
+                message: first.message,
+                ...(first.code ? {code: first.code} : {})
             });
         }
 
@@ -86,6 +88,8 @@ function processFileFunction(files, failures, theme, partialsFound) {
     };
 }
 
+const DEFAULT_CODE = 'GS005-TPL-ERR';
+
 const checkTemplatesCompile = function checkTemplatesCompile(theme, options) {
     const failures = [];
     const checkVersion = _.get(options, 'checkVersion', versions.default);
@@ -96,35 +100,34 @@ const checkTemplatesCompile = function checkTemplatesCompile(theme, options) {
     // Reset theme.helpers to make sure we only get helpers that are used
     theme.helpers = {};
 
-    // CASE: 001-deprecations checks only needs `rules` that start with `GS001-DEPR-`
-    const ruleRegex = /GS005-.*/g;
-
     const rulesToCheck = _.pickBy(ruleSet.rules, function (rule, ruleCode) {
-        if (ruleCode.match(ruleRegex)) {
-            return rule;
-        }
+        return /^GS005-/.test(ruleCode);
     });
 
     const processFile = processFileFunction(theme.files, failures, theme, partialsFound);
 
-    _.each(rulesToCheck, function (check, ruleCode) {
-        const linter = new ASTLinter({
-            partials: theme.partials,
-            helpers: ruleSet.knownHelpers
-        });
+    const linter = new ASTLinter({
+        partials: theme.partials,
+        helpers: ruleSet.knownHelpers
+    });
 
-        _.each(theme.files, function (themeFile) {
-            let templateTest = themeFile.file.match(/(?<!partials\/.+?)\.hbs$/);
+    _.each(theme.files, function (themeFile) {
+        if (themeFile.file.match(/(?<!partials\/.+?)\.hbs$/)) {
+            processFile(linter, themeFile);
+        }
+    });
 
-            if (templateTest) {
-                processFile(linter, themeFile);
-            }
-        });
+    theme.partials = Object.keys(partialsFound);
 
-        theme.partials = Object.keys(partialsFound);
+    // Route each failure to its target rule code (default for parse errors,
+    // missing partials, and missing helpers — they're all GS005-TPL-ERR).
+    // The lint rules attach a `code` field to flag the rule they belong to.
+    const failuresByCode = _.groupBy(failures, f => f.code || DEFAULT_CODE);
 
-        if (failures.length > 0) {
-            theme.results.fail[ruleCode] = {failures: failures};
+    _.each(rulesToCheck, function (rule, ruleCode) {
+        const matchingFailures = (failuresByCode[ruleCode] || []).map(f => _.omit(f, 'code'));
+        if (matchingFailures.length > 0) {
+            theme.results.fail[ruleCode] = {failures: matchingFailures};
         } else {
             theme.results.pass.push(ruleCode);
         }

--- a/lib/checks/005-template-compile.js
+++ b/lib/checks/005-template-compile.js
@@ -112,7 +112,7 @@ const checkTemplatesCompile = function checkTemplatesCompile(theme, options) {
     });
 
     _.each(theme.files, function (themeFile) {
-        if (themeFile.file.match(/(?<!partials\/.+?)\.hbs$/)) {
+        if (themeFile.normalizedFile.endsWith('.hbs') && !themeFile.normalizedFile.startsWith('partials/')) {
             processFile(linter, themeFile);
         }
     });

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -391,7 +391,7 @@ rules = {
         rule: 'Use the block form for dynamic partials',
         details: oneLineTrim`Inline dynamic partials (e.g. <code>{{> (dynamicPartial)}}</code>) throw a page error if the named partial doesn't exist. Use the block form, which falls back to the inner content when the partial is missing:<br>
         <code>&#123;&#123;#&gt; (dynamicPartial)&#125;&#125;fallback markup&#123;&#123;/undefined&#125;&#125;</code><br>
-        See the <a href="${docsBaseUrl}helpers/utility/partials/#partials" target=_blank>partials documentation</a> for details.`
+        See the <a href="${docsBaseUrl}helpers/utility/partials/#dynamic-partials" target=_blank>partials documentation</a> for details.`
     },
     'GS010-PJ-REQ': {
         level: 'error',

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -385,6 +385,13 @@ rules = {
         details: oneLineTrim`Oops! You seemed to have used invalid Handlebars syntax. This mostly happens when you use a helper that is not supported.<br>
         See the full list of available helpers <a href="${docsBaseUrl}helpers/" target=_blank>here</a>.`
     },
+    'GS005-NO-INLINE-DYNAMIC-PARTIAL': {
+        level: 'warning',
+        rule: 'Use the block form for dynamic partials',
+        details: oneLineTrim`Inline dynamic partials (e.g. <code>{{> (dynamicPartial)}}</code>) throw a page error if the named partial doesn't exist. Use the block form, which falls back to the inner content when the partial is missing:<br>
+        <code>&#123;&#123;#&gt; (dynamicPartial)&#125;&#125;fallback markup&#123;&#123;/undefined&#125;&#125;</code><br>
+        See the <a href="${docsBaseUrl}structure/" target=_blank>partials documentation</a> for details.`
+    },
     'GS010-PJ-REQ': {
         level: 'error',
         rule: '<code>package.json</code> file should be present',

--- a/lib/specs/v1.js
+++ b/lib/specs/v1.js
@@ -386,11 +386,12 @@ rules = {
         See the full list of available helpers <a href="${docsBaseUrl}helpers/" target=_blank>here</a>.`
     },
     'GS005-NO-INLINE-DYNAMIC-PARTIAL': {
-        level: 'warning',
+        level: 'error',
+        fatal: true,
         rule: 'Use the block form for dynamic partials',
         details: oneLineTrim`Inline dynamic partials (e.g. <code>{{> (dynamicPartial)}}</code>) throw a page error if the named partial doesn't exist. Use the block form, which falls back to the inner content when the partial is missing:<br>
         <code>&#123;&#123;#&gt; (dynamicPartial)&#125;&#125;fallback markup&#123;&#123;/undefined&#125;&#125;</code><br>
-        See the <a href="${docsBaseUrl}structure/" target=_blank>partials documentation</a> for details.`
+        See the <a href="${docsBaseUrl}helpers/utility/partials/#partials" target=_blank>partials documentation</a> for details.`
     },
     'GS010-PJ-REQ': {
         level: 'error',

--- a/test/005-template-compile.test.js
+++ b/test/005-template-compile.test.js
@@ -10,8 +10,9 @@ describe('005 Template compile', function () {
                 utils.assertValidThemeObject(output);
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -22,8 +23,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -31,7 +33,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid templates', function () {
             return utils.testCheck(thisCheck, '005-compile/v1/invalid', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -82,8 +84,9 @@ describe('005 Template compile', function () {
                 utils.assertValidThemeObject(output);
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -94,8 +97,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -103,7 +107,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid templates', function () {
             return utils.testCheck(thisCheck, '005-compile/v2/invalid', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -154,8 +158,9 @@ describe('005 Template compile', function () {
                 utils.assertValidThemeObject(output);
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -166,8 +171,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -175,7 +181,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid templates', function () {
             return utils.testCheck(thisCheck, '005-compile/v3/invalid', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -215,8 +221,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -238,8 +245,9 @@ describe('005 Template compile', function () {
                 utils.assertValidThemeObject(output);
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -250,8 +258,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -259,7 +268,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid templates', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/invalid', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -286,7 +295,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid partials', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/invalid-partial', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -304,7 +313,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme with invalid folder partials', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/invalid-partial-folder', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -322,7 +331,7 @@ describe('005 Template compile', function () {
         it('should output errors for a theme in subfolders', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/invalid-folder', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -374,12 +383,16 @@ describe('005 Template compile', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/invalid-with-dynamic-partials', options).then(function (output) {
                 utils.assertValidThemeObject(output);
 
-                utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
-                utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
-                expect(output.results.fail['GS005-TPL-ERR'].failures.length).toEqual(1);
-                expect(output.results.fail['GS005-TPL-ERR'].failures[0].ref).toEqual('post.hbs');
-                utils.assertContains(output.results.fail['GS005-TPL-ERR'].failures[0].message, 'Inlined dynamic partials');
+                utils.assertObjectKeys(output.results.fail, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
+                utils.assertValidFailObject(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
+                expect(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures.length).toEqual(1);
+                expect(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].ref).toEqual('post.hbs');
+                utils.assertContains(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].message, 'Inline dynamic partial used');
 
+                // The GS005-TPL-ERR rule still passes for this fixture — the
+                // template compiles fine; the inline dynamic partial is a lint
+                // warning, not a parse error.
+                utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
             });
         });
 
@@ -389,8 +402,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -401,8 +415,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
             });
         });
@@ -418,7 +433,7 @@ describe('005 Template compile', function () {
         it('Detects missing partials in code flows', function () {
             return utils.testCheck(thisCheck, '005-compile/v4/missing-partials', options).then(function (output) {
                 utils.assertValidThemeObject(output);
-                expect(output.results.pass).toEqual([]);
+                expect(output.results.pass).toEqual(['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
 
                 utils.assertObjectKeys(output.results.fail, 'GS005-TPL-ERR');
                 utils.assertValidFailObject(output.results.fail['GS005-TPL-ERR']);
@@ -439,8 +454,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
                 expect(output.partials).toHaveLength(1);
                 utils.assertContains(output.partials, 'mypartial');
@@ -454,8 +470,9 @@ describe('005 Template compile', function () {
 
                 expect(output.results.fail).toEqual({});
 
-                expect(output.results.pass).toHaveLength(1);
+                expect(output.results.pass).toHaveLength(2);
                 utils.assertContains(output.results.pass, 'GS005-TPL-ERR');
+                utils.assertContains(output.results.pass, 'GS005-NO-INLINE-DYNAMIC-PARTIAL');
 
                 expect(output.partials).toHaveLength(1);
                 utils.assertContains(output.partials, 'recursive');

--- a/test/005-template-compile.test.js
+++ b/test/005-template-compile.test.js
@@ -387,7 +387,8 @@ describe('005 Template compile', function () {
                 utils.assertValidFailObject(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL']);
                 expect(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures.length).toEqual(1);
                 expect(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].ref).toEqual('post.hbs');
-                utils.assertContains(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].message, 'Inline dynamic partial used');
+                utils.assertContains(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].message, 'Inline dynamic partial on line 1:');
+                utils.assertContains(output.results.fail['GS005-NO-INLINE-DYNAMIC-PARTIAL'].failures[0].message, '{{>(lookup');
 
                 // The GS005-TPL-ERR rule still passes for this fixture — the
                 // template compiles fine; the inline dynamic partial is a lint

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -71,7 +71,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(96);
+            expect(theme.results.pass).toHaveLength(97);
             expect(theme.results.pass).toContain('GS005-TPL-ERR');
 
             utils.assertObjectKeys(theme.results.fail,
@@ -110,7 +110,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(33);
+            expect(theme.results.pass).toHaveLength(34);
             expect(theme.results.pass).toContain('GS005-TPL-ERR');
 
             utils.assertObjectKeys(theme.results.fail,
@@ -145,7 +145,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(96);
+            expect(theme.results.pass).toHaveLength(97);
             expect(theme.results.pass).toContain('GS005-TPL-ERR');
 
             utils.assertObjectKeys(theme.results.fail,
@@ -180,7 +180,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(99);
+            expect(theme.results.pass).toHaveLength(100);
             expect(theme.results.pass).toContain('GS005-TPL-ERR');
 
             utils.assertObjectKeys(theme.results.fail,
@@ -215,7 +215,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(109);
+            expect(theme.results.pass).toHaveLength(110);
             expect(theme.results.pass).toEqual([
                 'GS001-DEPR-PURL',
                 'GS001-DEPR-MD',
@@ -313,6 +313,7 @@ describe('Checker', function () {
                 'GS001-DEPR-CURR-SYM',
                 'GS001-DEPR-SITE-LANG',
                 'GS005-TPL-ERR',
+                'GS005-NO-INLINE-DYNAMIC-PARTIAL',
                 'GS030-ASSET-REQ',
                 'GS030-ASSET-SYM',
                 'GS060-JS-GUA',
@@ -359,7 +360,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(118);
+            expect(theme.results.pass).toHaveLength(119);
             expect(theme.results.pass).toEqual([
                 'GS001-DEPR-PURL',
                 'GS001-DEPR-MD',
@@ -457,6 +458,7 @@ describe('Checker', function () {
                 'GS001-DEPR-CURR-SYM',
                 'GS001-DEPR-SITE-LANG',
                 'GS005-TPL-ERR',
+                'GS005-NO-INLINE-DYNAMIC-PARTIAL',
                 'GS030-ASSET-REQ',
                 'GS030-ASSET-SYM',
                 'GS060-JS-GUA',
@@ -512,7 +514,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(123);
+            expect(theme.results.pass).toHaveLength(124);
             expect(theme.results.pass).toEqual([
                 'GS001-DEPR-PURL',
                 'GS001-DEPR-MD',
@@ -613,6 +615,7 @@ describe('Checker', function () {
                 'GS001-DEPR-FACEBOOK-URL',
                 'GS001-DEPR-AMP-TEMPLATE',
                 'GS005-TPL-ERR',
+                'GS005-NO-INLINE-DYNAMIC-PARTIAL',
                 'GS030-ASSET-REQ',
                 'GS030-ASSET-SYM',
                 'GS060-JS-GUA',
@@ -671,7 +674,7 @@ describe('Checker', function () {
             ]);
 
             // Short version of test above
-            expect(theme.results.pass).toHaveLength(123);
+            expect(theme.results.pass).toHaveLength(124);
             expect(theme.checkedVersion).toEqual('6.x');
         });
     });
@@ -686,7 +689,7 @@ describe('Checker', function () {
             ]);
 
             // Should default to v6 behavior
-            expect(theme.results.pass).toHaveLength(123);
+            expect(theme.results.pass).toHaveLength(124);
             expect(theme.checkedVersion).toEqual('6.x');
         });
     });


### PR DESCRIPTION
## Summary

Alternative to #814. Same goal — make the inline-dynamic-partial lint message useful — but rather than just rewriting the message string, splits the check into its own spec rule with proper severity.

The lint message in #814 was rendering inside the Theme updated dialog under:

> **Fatal: Templates must contain valid Handlebars**
> Oops! You seemed to have used invalid Handlebars syntax.

That's the GS005-TPL-ERR rule, which is correct for parse errors and missing helpers but wrong for "you used the inline form when block would be safer" — the template compiles fine, it's just risky style. The fatal red dot also overstates the impact.

## Change

- **New spec rule `GS005-NO-INLINE-DYNAMIC-PARTIAL`** in `lib/specs/v1.js` (inherited by all later specs). Level `warning`, not fatal. Title "Use the block form for dynamic partials". Body has the example and a link to the partials docs.
- **ast-linter rule tags its inline-partial failure with `code: 'GS005-NO-INLINE-DYNAMIC-PARTIAL'`**, distinguishing it from the "partial could not be found" failure (which stays as a default parse-error-level failure).
- **`005-template-compile.js` routes failures by their `code` field.** The default is still `GS005-TPL-ERR` for parse errors, missing partials, and missing helpers — only inline-dynamic-partial routes to the new code.
- **Side fix**: the check was iterating over every `GS005-*` rule running the linter once per iteration, with a shared `failures` array — meaning duplicate failures would be reported under each rule if there were ever more than one. Refactored to run the linter once and split failures by target code at the end.

## Result

| | Before | After |
|---|---|---|
| Section | Errors (Fatal) | Warnings |
| Title | "Templates must contain valid Handlebars" | "Use the block form for dynamic partials" |
| Body | "Oops! You seemed to have used invalid Handlebars syntax. This mostly happens when you use a helper that is not supported." | "Inline dynamic partials throw a page error if the named partial doesn't exist. Use the block form, which falls back to the inner content when the partial is missing: `{{#> (dynamicPartial)}}fallback markup{{/undefined}}`. See the partials documentation for details." |
| Affected files | "Use the block form for dynamic partials so the page survives a missing partial: `<code>{{#> (dynamicPartial)}}fallback markup{{/undefined}}</code>` instead of `<code>{{> (dynamicPartial)}}</code>`. See the `<a href=...>` partials documentation `</a>` for details." (with raw HTML rendering) | "Inline dynamic partial used" |
| Theme can activate | No (fatal) | Yes (warning) |

## Test plan

- [x] `yarn test` — 409 passing (updated assertions in `005-template-compile.test.js` for the new rule code, plus the `pass` counts across files now that two GS005-* rules exist)
- [x] `yarn lint` — clean
- [x] Manually verified in a running Ghost: theme upload that uses `{{> (concat "icons/social/" type)}}` returns under `warnings` with `GS005-NO-INLINE-DYNAMIC-PARTIAL`, not under errors. Theme activates.

## Scope comparison with #814

| | #814 | #815 (this PR) |
|---|---|---|
| Files changed | 2 | 5 |
| LOC | ~2 | ~88 added / 57 removed |
| Severity correct? | No (still fatal) | Yes (warning) |
| Title correct? | Says "Templates must contain valid Handlebars" | "Use the block form for dynamic partials" |
| Failure message renders cleanly | After commit `2958c06`, yes (plain text) | Yes (terse, body has the detail) |
| Side-effect | None | Fixes the GS005-* iteration bug that would duplicate failures if anyone added another GS005-* rule |

#814 is the minimum patch; this PR is the proper fix. Recommend taking this and closing #814.
