### PR TITLE
Rewrote the GS090 and GS100 custom-theme-setting rule wording

### DIFF
--- a/lib/ast-linter/rules/lint-no-unknown-custom-theme-settings.js
+++ b/lib/ast-linter/rules/lint-no-unknown-custom-theme-settings.js
@@ -6,7 +6,7 @@ module.exports = class NoUnknownCustomThemeSettings extends Rule {
             const name = node.parts[1];
             if (!this.isValidCustomThemeSettingReference(name)) {
                 this.log({
-                    message: `Missing Custom Theme Setting: "${name}"`,
+                    message: `Unknown {{@custom.${name}}} on line ${node.loc && node.loc.start.line}: ${this.sourceForNode(node)}`,
                     line: node.loc && node.loc.start.line,
                     column: node.loc && node.loc.start.column,
                     source: this.sourceForNode(node)

--- a/lib/checks/100-custom-template-settings-usage.js
+++ b/lib/checks/100-custom-template-settings-usage.js
@@ -26,12 +26,12 @@ const ruleImplementations = {
             const config = Object.keys(theme.customSettings);
             const notUsedVariable = config.filter(x => !result.customThemeSettings.has(x));
 
-            if (notUsedVariable.length > 0) {
+            notUsedVariable.forEach((name) => {
                 log.failure({
-                    message: `Found unused variables: ${notUsedVariable.map(x => '@custom.' + x).join(', ')}`,
+                    message: `config.custom.${name} is declared but never referenced from a template`,
                     ref: 'package.json'
                 });
-            }
+            });
         }
     }
 };

--- a/lib/specs/v4.js
+++ b/lib/specs/v4.js
@@ -172,9 +172,9 @@ let rules = {
     },
     'GS090-NO-UNKNOWN-CUSTOM-THEME-SETTINGS': {
         level: 'error',
-        rule: 'An unknown custom theme setting has been used.',
         fatal: false,
-        details: oneLineTrim`The custom theme setting should all be defined in the package.json <code>config.custom</code> object.`
+        rule: 'Remove or correct the unknown <code>{{@custom}}</code> setting',
+        details: oneLineTrim`Every <code>{{@custom.<i>name</i>}}</code> reference in a template needs a matching entry in <code>config.custom</code> in <code>package.json</code>. An unrecognised setting renders as empty. See the <a href="${docsBaseUrl}custom-settings/" target=_blank>custom settings documentation</a> for details.`
     },
     'GS090-NO-UNKNOWN-CUSTOM-THEME-SELECT-VALUE-IN-MATCH': {
         level: 'error',
@@ -209,8 +209,8 @@ let rules = {
 
     'GS100-NO-UNUSED-CUSTOM-THEME-SETTING': {
         level: 'error',
-        rule: 'A custom theme setting defined in <code>package.json</code> hasn\'t been used in any theme file.',
-        details: oneLineTrim`Custom theme settings defined in <code>package.json</code> must be used at least once in the theme templates.`
+        rule: 'Use or remove the unused <code>config.custom</code> setting',
+        details: oneLineTrim`A setting declared in <code>config.custom</code> in <code>package.json</code> appears in the admin Customize panel but has no effect unless referenced from a template with <code>{{@custom.<i>name</i>}}</code>. Either use the setting from a template or drop it from <code>package.json</code>. See the <a href="${docsBaseUrl}custom-settings/" target=_blank>custom settings documentation</a> for details.`
     },
 
     'GS050-CSS-KGCO': cssCardRule('callout', 'kg-callout-card'),

--- a/test/100-custom-template-settings-usage.test.js
+++ b/test/100-custom-template-settings-usage.test.js
@@ -21,8 +21,9 @@ describe('100 custom template settings usage', function () {
                 expect(Object.keys(output.results.fail)).toEqual(['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
 
                 utils.assertValidFailObject(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/color_scheme/);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/show_logo/);
+                const messages = output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures.map(f => f.message);
+                expect(messages.some(m => /color_scheme/.test(m))).toBe(true);
+                expect(messages.some(m => /show_logo/.test(m))).toBe(true);
 
             });
         });
@@ -99,8 +100,9 @@ describe('100 custom template settings usage', function () {
                 expect(Object.keys(output.results.fail)).toEqual(['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
 
                 utils.assertValidFailObject(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/color_scheme/);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/show_logo/);
+                const messages = output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures.map(f => f.message);
+                expect(messages.some(m => /color_scheme/.test(m))).toBe(true);
+                expect(messages.some(m => /show_logo/.test(m))).toBe(true);
 
             });
         });
@@ -177,8 +179,9 @@ describe('100 custom template settings usage', function () {
                 expect(Object.keys(output.results.fail)).toEqual(['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
 
                 utils.assertValidFailObject(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING']);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/color_scheme/);
-                expect(output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures[0].message).toMatch(/show_logo/);
+                const messages = output.results.fail['GS100-NO-UNUSED-CUSTOM-THEME-SETTING'].failures.map(f => f.message);
+                expect(messages.some(m => /color_scheme/.test(m))).toBe(true);
+                expect(messages.some(m => /show_logo/.test(m))).toBe(true);
 
             });
         });


### PR DESCRIPTION
## Summary

Follow-up to #813 (GS110 rewrite) and #815 (inline-dynamic-partial rule). Same pattern applied to the two custom-theme-setting rules surfaced in the audit.

## Changes

### `GS090-NO-UNKNOWN-CUSTOM-THEME-SETTINGS`

|  | Before | After |
|---|---|---|
| Title | "An unknown custom theme setting has been used." | "Remove or correct the unknown `{{@custom}}` setting" |
| Body  | "The custom theme setting should all be defined in the package.json `config.custom` object." | "Every `{{@custom.<name>}}` reference in a template needs a matching entry in `config.custom` in `package.json`. An unrecognised setting renders as empty. See the custom settings documentation for details." |
| Per-failure message | `Missing Custom Theme Setting: "color_scheme"` | `Unknown {{@custom.color_scheme}} on line 12: {{@custom.color_scheme}}` |

### `GS100-NO-UNUSED-CUSTOM-THEME-SETTING`

|  | Before | After |
|---|---|---|
| Title | "A custom theme setting defined in `package.json` hasn't been used in any theme file." | "Use or remove the unused `config.custom` setting" |
| Body  | "Custom theme settings defined in `package.json` must be used at least once in the theme templates." | "A setting declared in `config.custom` in `package.json` appears in the admin Customize panel but has no effect unless referenced from a template with `{{@custom.<name>}}`. Either use the setting from a template or drop it from `package.json`. See the custom settings documentation for details." |
| Per-failure message | `Found unused variables: @custom.color_scheme, @custom.show_logo` (one failure with all names joined) | `config.custom.color_scheme is declared but never referenced from a template` (one failure per setting) |

## Notes

- **GS100 framing**: the offence lives in `package.json`, not in a template, so the title talks about `config.custom` (the JSON key) rather than `{{@custom}}` (the helper). Body still mentions the helper once because that's what "use it" means in context.
- **GS090 framing**: stays handlebars-flavoured because the offence is a `{{@custom.foo}}` reference in a template.
- **Severity unchanged** — both stay `level: error`. Unlike GS110's missing-toggle (where the editor setting silently fails to apply), these flag a real shape mismatch between the theme's declared and used surface that's worth resolving before shipping.

## Test plan

- [x] `yarn test` — 409 passing (updated the three `100-custom-template-settings-usage.test.js` assertions to check the new per-setting failure list)
- [x] `yarn lint` — clean
