### PR TITLE
✨ Recognised the @gift theme data global in v6

### DIFF
--- a/lib/ast-linter/linter.js
+++ b/lib/ast-linter/linter.js
@@ -44,7 +44,8 @@ class Linter {
                 partials: this.options.partials,
                 helpers: this.options.helpers,
                 inlinePartials: this.options.inlinePartials,
-                customThemeSettings: this.options.customThemeSettings
+                customThemeSettings: this.options.customThemeSettings,
+                knownGlobals: this.options.knownGlobals
             });
 
             nodeHandlers.push({

--- a/lib/ast-linter/rules/base.js
+++ b/lib/ast-linter/rules/base.js
@@ -11,6 +11,8 @@ module.exports = class BaseRule {
         this.customThemeSettings = options.customThemeSettings;
         // Keep in sync with `pageBuilderProperties` in lib/specs/v5.js.
         this.knownPageBuilderProperties = options.knownPageBuilderProperties || ['show_title_and_feature_image'];
+        // version-specific globals from the active spec, e.g. `@gift` in v6+
+        this.knownGlobals = options.knownGlobals || [];
     }
 
     getVisitor({fileName} = {}) {
@@ -20,7 +22,7 @@ module.exports = class BaseRule {
         // keep track of the locals that are available in the current context.
         // enables checks in rules to see if a MustacheStatement is referring
         // to a known local
-        const scope = (this.scope = new Scope());
+        const scope = (this.scope = new Scope({extraGlobals: this.knownGlobals}));
 
         // these are the node types that we care about
         const nodeTypes = [

--- a/lib/ast-linter/rules/internal/scope.js
+++ b/lib/ast-linter/rules/internal/scope.js
@@ -26,9 +26,10 @@ const dataVars = {
 };
 
 // unless we move from lodash to a glob match, we just need to handle all custom since we can't allowlist those
-function isOnAllowlist(parts) {
+// `extraGlobals` carries version-specific globals from the active spec (e.g. `@gift` in v6+)
+function isOnAllowlist(parts, extraGlobals = []) {
     const variable = parts && parts[0];
-    return ghostGlobals[variable] || dataVars[variable] || false;
+    return ghostGlobals[variable] || dataVars[variable] || extraGlobals.includes(variable) || false;
 }
 
 // true = property exists
@@ -175,8 +176,9 @@ class Frame {
 }
 
 class Scope {
-    constructor({templateFileName} = {}) {
+    constructor({templateFileName, extraGlobals = []} = {}) {
         this.frames = [];
+        this.extraGlobals = extraGlobals;
 
         if (templateFileName) {
             this.frames.push(new Frame);
@@ -233,12 +235,12 @@ class Scope {
 
         // they can be direct [Mustache] statements {{@foo}}...
         if (node.type === 'MustacheStatement' && node.path.data) {
-            return isOnAllowlist(node.path.parts);
+            return isOnAllowlist(node.path.parts, this.extraGlobals);
         }
 
         // ... or indirect using helpers, e.g. {{#match @foo.bar}}{{/match}}
         if (node.type === 'PathExpression') {
-            return isOnAllowlist(node.parts);
+            return isOnAllowlist(node.parts, this.extraGlobals);
         }
 
         let name = getNodeName(node);

--- a/lib/checks/120-no-unknown-globals.js
+++ b/lib/checks/120-no-unknown-globals.js
@@ -108,7 +108,8 @@ const checkNoUnknownGlobals = function checkNoUnknownGlobals(theme, options) {
     _.each(rulesToCheck, function (check, ruleCode) {
         const linter = new ASTLinter({
             partials: theme.partials,
-            helpers: ruleSet.knownHelpers
+            helpers: ruleSet.knownHelpers,
+            knownGlobals: ruleSet.knownGlobals
         });
 
         _.each(theme.files, function (themeFile) {

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -774,6 +774,9 @@ module.exports = {
     templates: templates,
     rules: rules,
     pageBuilderProperties: ['show_title_and_feature_image'],
+    // version-specific template data globals on top of the shared allowlist in
+    // lib/ast-linter/rules/internal/scope.js (e.g. `@gift` is added in v6)
+    knownGlobals: [],
     /**
      * Copy of Ghost defaults for https://github.com/TryGhost/Ghost/blob/e25f1df0ae551c447da0d319bae06eadf9665444/core/frontend/services/theme-engine/config/defaults.json
      */

--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -62,5 +62,7 @@ module.exports = {
     templates: templates,
     rules: rules,
     pageBuilderProperties: previousSpec.pageBuilderProperties,
+    // `@gift` is exposed to themes via the gift-links reader route in Ghost 6
+    knownGlobals: _.union(previousSpec.knownGlobals, ['gift']),
     defaultPackageJSON: previousSpec.defaultPackageJSON
 };

--- a/test/120-no-unknown-globals.test.js
+++ b/test/120-no-unknown-globals.test.js
@@ -36,6 +36,17 @@ describe('120 No unknown globals', function () {
 
             });
         });
+
+        it('should flag the @gift global (only available from v6)', function () {
+            return utils.testCheck(thisCheck, '120-no-unknown-globals/v5/with-gift', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                utils.assertObjectKeys(output.results.fail, 'GS120-NO-UNKNOWN-GLOBALS');
+                utils.assertValidFailObject(output.results.fail['GS120-NO-UNKNOWN-GLOBALS']);
+                expect(output.results.fail['GS120-NO-UNKNOWN-GLOBALS'].failures).toHaveLength(2);
+
+            });
+        });
     });
 
     describe('v6', function () {
@@ -65,6 +76,16 @@ describe('120 No unknown globals', function () {
 
         it('should pass specific data variables like {{@first}}', function () {
             return utils.testCheck(thisCheck, '120-no-unknown-globals/v5/valid-with-locals', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                expect(output.results.pass).toHaveLength(1);
+                utils.assertContains(output.results.pass, 'GS120-NO-UNKNOWN-GLOBALS');
+
+            });
+        });
+
+        it('should pass the @gift global', function () {
+            return utils.testCheck(thisCheck, '120-no-unknown-globals/v5/with-gift', options).then(function (output) {
                 utils.assertValidThemeObject(output);
 
                 expect(output.results.pass).toHaveLength(1);

--- a/test/fixtures/themes/120-no-unknown-globals/v5/with-gift/default.hbs
+++ b/test/fixtures/themes/120-no-unknown-globals/v5/with-gift/default.hbs
@@ -1,0 +1,6 @@
+{{#if @gift}}
+    {{!-- Reader arrived via a gift link, show a banner --}}
+    <div class="gift-banner" data-post-id="{{@gift.post_id}}">
+        <p>You're reading a gifted post.</p>
+    </div>
+{{/if}}


### PR DESCRIPTION
## What

Teaches gscan that `@gift` is a known template data global in **Ghost 6**, so themes building their own gift-link reader UI with `{{#if @gift}}` / `{{@gift.post_id}}` don't fail validation with a `GS120-NO-UNKNOWN-GLOBALS` ("not a known global") error.

Ghost 6 exposes `@gift` to themes via the gift-links reader route (`/g/<slug>`). This should land **before** the feature is documented so theme authors writing `@gift` templates don't hit false errors.

## Why version-scoped (v6 only)

`@gift` only exists in Ghost 6. A v5-targeting theme using `@gift` would break on Ghost 5, so it's a **version-scoped** global rather than a flat allowlist entry — v6 recognises it, v5 still (correctly) flags it.

This mirrors how `pageBuilderProperties` is defined per-spec: the active spec's new `knownGlobals` list is threaded through the AST linter into the scope's allowlist check.

- `lib/specs/v6.js` — `knownGlobals: _.union(previousSpec.knownGlobals, ['gift'])`
- `lib/specs/v5.js` — `knownGlobals: []`
- `lib/checks/120-no-unknown-globals.js` → `lib/ast-linter/linter.js` → `lib/ast-linter/rules/base.js` → `lib/ast-linter/rules/internal/scope.js` — `knownGlobals` flows into `new Scope({extraGlobals})`

The shared base allowlist (`site`/`member`/etc.) stays in `scope.js`; `knownGlobals` is purely additive per version.

## Tests

- New version-neutral fixture `test/fixtures/themes/120-no-unknown-globals/v5/with-gift/` (uses `{{#if @gift}}` + `{{@gift.post_id}}`)
- **v5**: asserts `@gift` is flagged (2 failures)
- **v6**: asserts it passes
- Full suite green (411 tests), lint clean

## Downstream (separate)

gscan is a published package — this does not change in-product theme validation until Ghost core bumps its `gscan` dependency to the release that includes this. That bump is a follow-up once this is released.

Refs https://linear.app/ghost/issue/BER-3738