### PR TITLE
Add arity validation for `{{#if}}` and `{{#unless}}` helpers

### DIFF
--- a/lib/ast-linter/rules/index.js
+++ b/lib/ast-linter/rules/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'GS090-NO-PRICE-DATA-MONTHLY-YEARLY': require('./lint-no-price-data-monthly-yearly'),
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': require('./lint-no-limit-all-in-get-helper'),
     'GS090-NO-LIMIT-OVER-100-IN-GET-HELPER': require('./lint-no-limit-over-100-in-get-helper'),
+    'GS090-NO-INVALID-CONDITIONAL-ARGUMENTS': require('./lint-no-multi-param-conditionals'),
     'GS110-NO-UNKNOWN-PAGE-BUILDER-USAGE': require('./lint-no-unknown-page-properties'),
     'GS120-NO-UNKNOWN-GLOBALS': require('./lint-no-unknown-globals'),
     'no-multi-param-conditionals': require('./lint-no-multi-param-conditionals'),

--- a/lib/ast-linter/rules/lint-no-img-url-in-conditionals.js
+++ b/lib/ast-linter/rules/lint-no-img-url-in-conditionals.js
@@ -9,7 +9,7 @@ const message = 'The {{img_url}} helper should not be used as a parameter to {{#
 module.exports = class NoMultiParamConditionals extends Rule {
     _checkForImgUrlParam(node) {
         const isConditional = node.path.original === 'if' || node.path.original === 'unless';
-        const hasImgUrlParam = isConditional && node.params[0].original === 'img_url';
+        const hasImgUrlParam = isConditional && node.params[0] && node.params[0].original === 'img_url';
         let fix;
 
         if (isConditional && hasImgUrlParam) {

--- a/lib/ast-linter/rules/lint-no-multi-param-conditionals.js
+++ b/lib/ast-linter/rules/lint-no-multi-param-conditionals.js
@@ -1,22 +1,24 @@
 // https://github.com/TryGhost/gscan/issues/85
 
 const Rule = require('./base');
-const message = 'Multiple params are not supported in an {{if}} or {{unless}} statement.';
+const message = 'The {{#if}} and {{#unless}} helpers require exactly one argument.';
 
 // valid:
 // {{#if foo}}
 // {{#unless foo}}
 
 // invalid:
+// {{#if}}
 // {{#if foo bar}}
+// {{#unless}}
 // {{#unless foo bar}}
 
 module.exports = class NoMultiParamConditionals extends Rule {
     _checkForMultipleParams(node) {
         const isConditional = node.path.original === 'if' || node.path.original === 'unless';
-        const hasTooManyParams = node.params.length > 1;
+        const hasInvalidParamCount = node.params.length !== 1;
 
-        if (isConditional && hasTooManyParams) {
+        if (isConditional && hasInvalidParamCount) {
             this.log({
                 message,
                 line: node.loc && node.loc.start.line,

--- a/lib/specs/v6.js
+++ b/lib/specs/v6.js
@@ -11,6 +11,12 @@ const previousRules = previousSpec.rules;
 let knownHelpers = ['split', 'json', 'color_to_rgba', 'contrast_text_color', 'raw', 'search', 'social_accounts'];
 let templates = [];
 let rules = {
+    'GS090-NO-INVALID-CONDITIONAL-ARGUMENTS': {
+        level: 'error',
+        fatal: true,
+        rule: 'Use exactly one argument in <code>{{#if}}</code> and <code>{{#unless}}</code> helpers',
+        details: oneLineTrim`The <code>{{#if}}</code> and <code>{{#unless}}</code> helpers only support one argument. To compare values, use a supported helper such as <code>{{#match}}</code>, for example <code>{{#match statusCode 404}}</code>.`
+    },
     'GS090-NO-LIMIT-ALL-IN-GET-HELPER': {
         level: 'warning',
         rule: 'Using <code>limit="all"</code> in <code>{{#get}}</code> helper is not supported',

--- a/test/090-template-syntax.test.js
+++ b/test/090-template-syntax.test.js
@@ -225,6 +225,21 @@ describe('090 Template syntax', function () {
     describe('v6', function () {
         const options = {checkVersion: 'v6'};
 
+        it('should fail when {{#if}} has more than one argument', async function () {
+            const output = await utils.testCheck(thisCheck, '090-template-syntax/no-invalid-conditional-arguments', options);
+            utils.assertValidThemeObject(output);
+
+            expect(Object.keys(output.results.fail)).toEqual([
+                'GS090-NO-INVALID-CONDITIONAL-ARGUMENTS'
+            ]);
+            expect(output.results.fail['GS090-NO-INVALID-CONDITIONAL-ARGUMENTS'].failures).toEqual([
+                {
+                    ref: 'error.hbs',
+                    message: 'The {{#if}} and {{#unless}} helpers require exactly one argument. (L2)'
+                }
+            ]);
+        });
+
         it('should fail when {{author}} helper is used in post context', async function () {
             const output = await utils.testCheck(thisCheck, '090-template-syntax/no-author-helper-in-post-context/post-context', options);
             utils.assertValidThemeObject(output);

--- a/test/ast-linter.test.js
+++ b/test/ast-linter.test.js
@@ -49,6 +49,17 @@ describe('ast-linter', function () {
             expect(results[0].line).toEqual(2);
             expect(results[0].column).toEqual(0);
         });
+
+        it('should reject using no params in a conditional', function () {
+            const source = '{{#unless}}{{/unless}}';
+            const parsed = ASTLinter.parse(source);
+            const results = linter
+                .verify({parsed, moduleId: 'simple.hbs', source})
+                .filter(error => error.rule === 'no-multi-param-conditionals');
+            expect(results).toHaveLength(1);
+            expect(results[0].line).toEqual(1);
+            expect(results[0].column).toEqual(0);
+        });
     });
 
     describe('Helper extraction', function () {

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -514,7 +514,7 @@ describe('Checker', function () {
                 {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
             ]);
 
-            expect(theme.results.pass).toHaveLength(125);
+            expect(theme.results.pass).toHaveLength(126);
             expect(theme.results.pass).toEqual([
                 'GS001-DEPR-PURL',
                 'GS001-DEPR-MD',
@@ -637,6 +637,7 @@ describe('Checker', function () {
                 'GS090-NO-PRICE-DATA-MONTHLY-YEARLY',
                 'GS090-NO-TIER-PRICE-AS-OBJECT',
                 'GS090-NO-TIER-BENEFIT-AS-OBJECT',
+                'GS090-NO-INVALID-CONDITIONAL-ARGUMENTS',
                 'GS090-NO-LIMIT-ALL-IN-GET-HELPER',
                 'GS090-NO-LIMIT-OVER-100-IN-GET-HELPER',
                 'GS120-NO-UNKNOWN-GLOBALS',
@@ -675,7 +676,7 @@ describe('Checker', function () {
             ]);
 
             // Short version of test above
-            expect(theme.results.pass).toHaveLength(125);
+            expect(theme.results.pass).toHaveLength(126);
             expect(theme.checkedVersion).toEqual('6.x');
         });
     });
@@ -690,7 +691,7 @@ describe('Checker', function () {
             ]);
 
             // Should default to v6 behavior
-            expect(theme.results.pass).toHaveLength(125);
+            expect(theme.results.pass).toHaveLength(126);
             expect(theme.checkedVersion).toEqual('6.x');
         });
     });

--- a/test/fixtures/themes/090-template-syntax/no-invalid-conditional-arguments/error.hbs
+++ b/test/fixtures/themes/090-template-syntax/no-invalid-conditional-arguments/error.hbs
@@ -1,0 +1,6 @@
+{{!< default}}
+{{#if statusCode "==" 404}}
+    Not found
+{{else}}
+    Something went wrong
+{{/if}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1851/

- Added a v6 rule for invalid `{{#if}}` and `{{#unless}}` argument counts
- Tightened the AST linter so empty conditionals are also rejected
- Updated fixtures and checker expectations to cover the new failure case

