### PR TITLE
Fixed theme zip extraction permissions

### DIFF
--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -32,7 +32,9 @@ const resolveBaseDir = async (zipPath) => {
 const readZip = (zip, options = {}) => {
     const tempUuid = randomUUID();
     const tempPath = os.tmpdir() + '/' + tempUuid;
-    const extractOptions = {};
+    const extractOptions = {
+        ensureOwnerPermissions: true
+    };
 
     if (options.limits) {
         extractOptions.limits = options.limits;

--- a/test/read-zip.test.js
+++ b/test/read-zip.test.js
@@ -140,7 +140,10 @@ describe('Zip file handler can read zip files', function () {
             const zip = await mocked.readZip({path: '/tmp/theme.zip', name: 'theme.zip'}, {limits});
             tempDirs.push(zip.origPath);
 
-            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {limits});
+            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {
+                ensureOwnerPermissions: true,
+                limits
+            });
         } finally {
             mocked.restore();
         }
@@ -162,7 +165,9 @@ describe('Zip file handler can read zip files', function () {
                 errorDetails: extractError.message
             });
 
-            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {});
+            expect(extract).toHaveBeenCalledWith('/tmp/theme.zip', expect.any(String), {
+                ensureOwnerPermissions: true
+            });
         } finally {
             mocked.restore();
         }


### PR DESCRIPTION
ref https://github.com/TryGhost/framework/pull/761
ref https://linear.app/ghost/issue/ONC-1838/timeout-on-theme-upload

Some theme zip files have read-only folder permissions. When an user uploads one of these themes, GScan needs to unzip the archive and create files inside those folders. If the folders are not writable by the owner, extraction can get stuck and the theme upload appears to freeze in the UI without a useful error message.

With this change, GScan opts into the new `@tryghost/zip@3.5.0` owner-permission normalization while extracting theme uploads. Directories are normalized so the owner can read, write, and traverse them, and files are normalized so the owner can read and write them. The original zip is not modified; only the temporary extracted copy is made usable for validation and installation.

The result is that themes with incorrect folder permissions can still be uploaded successfully instead of leaving the user stuck on a frozen upload.