### PR TITLE
Improved CI trust gates for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,48 @@ on:
       - main
       - 'renovate/*'
   workflow_call:
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [22.13.1, 24]
     env:
+      CI: true
       FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
           FORCE_COLOR: 0
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - run: yarn
-      - run: yarn test
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests, coverage, and lint
+        run: yarn test
+
+  required-checks-pass:
+    name: Required checks pass
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success")' > /dev/null

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ module.exports = defineConfig({
             exclude: ['lib/faker/**'],
             reporter: ['html', 'text-summary'],
             thresholds: {
-                statements: 95,
+                statements: 97,
                 branches: 95,
-                functions: 95,
-                lines: 95
+                functions: 97,
+                lines: 97
             }
         }
     }


### PR DESCRIPTION
## Summary

- add a fail-closed `Required checks pass` aggregator for the supported Node matrix
- enforce read-only workflow permissions and frozen-lockfile installs
- run every matrix lane even when another lane fails
- ratchet statements, functions, and lines coverage thresholds from 95% to 97%

## CI trust evidence

- Baseline coverage: 98.53% statements, 95.06% branches, 98.17% functions, 98.55% lines
- Final coverage: unchanged at the same measured levels
- Enforced thresholds: 97% statements, 95% branches, 97% functions, 97% lines
- Runtime contract: Node 22.13.1 as the exact lower bound and Node 24 as the other supported major
- Package manager: Yarn 1 with `yarn.lock`; CI now uses `--frozen-lockfile`
- Recent PR CI baseline: 51 seconds total, with Node 24 as the 47-second critical path
- After duration: not available until this workflow runs on the PR

### Critical-path map

- Library API: `check` and `checkZip` exercise real theme directories and zip fixtures
- CLI: direct command execution is covered by the CLI smoke test
- Web app: GET/POST/error rendering paths are not covered and `app/**` remains outside coverage
- Visual UI: no visual-regression gate exists

No new third-party mocks were added. Existing tests use real local theme fixtures and only isolate package boundaries where already established.

## Validation

- `yarn install --frozen-lockfile`
- `yarn test` on Node 22.13.1
- `yarn test` on Node 24
- forced 100% line threshold correctly exited non-zero
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Trust level

Medium trust in CI. Dependency breakage in the library or CLI should fail PR CI, but HTTP acceptance and visual-regression coverage are still required for High trust.