### PR TITLE
Pin npm and disable lifecycle scripts in workflows

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,5 +20,5 @@ jobs:
           node-version: 24 # TODO: return to lts/* once 1) we're back to passing runs and 2) 24 is added to package.json
           cache: yarn
 
-      - run: yarn
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: node test/valid-doc-links.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Run tests, coverage, and lint
         run: yarn test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       # npm 11+ is required for npm Trusted Publishing (OIDC).
-      - name: Install npm 11
-        run: npm install -g npm@11
+      - name: Install npm 11.19.0
+        run: npm install -g npm@11.19.0
 
       - name: Install dependencies
         run: yarn --prefer-offline --ignore-scripts --frozen-lockfile


### PR DESCRIPTION
## What changed

- pin the npm CLI used for OIDC publishing to `npm@11.19.0`
- disable dependency lifecycle scripts during the main CI install
- make the scheduled link-check install frozen and disable dependency lifecycle scripts there too
- preserve the existing ignored-script install in the publish job

## Why

The publish workflow previously resolved `npm@11` at runtime, so the exact executable used by a job with `id-token: write` could change without a repository review. The CI and scheduled link-check installs also allowed dependency lifecycle scripts to execute.

`npm@11.19.0` is the current npm 11 release (`next-11`) in the public registry as of 2026-08-06. It was published on 2026-07-29, beyond the project's 72-hour dependency cooling-off period, supports the repository's Node versions (`^20.17.0 || >=22.9.0`), and resolves with registry integrity `sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==`.

This reduces supply-chain exposure without changing GScan runtime behavior or the existing OIDC/provenance publishing flow.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn test` — 27 test files and 423 tests passed, followed by ESLint
- `npm exec --yes --package npm@11.19.0 -- npm --version` — `11.19.0`
- `npm exec --yes --package npm@11.19.0 -- npm pack --dry-run --ignore-scripts`
- `node test/valid-doc-links.js` — executed after the hardened install; still exits on existing live-content failures (six external-href rule entries and the removed `/themes/helpers/labs/` URL returning 404)

Refs [PLA-316](https://linear.app/ghost/issue/PLA-316/pin-npm-and-disable-unreviewed-lifecycle-scripts-in-gscan-workflows)
