### PR TITLE
Fix false-positive {{author}} deprecation warning inside {{#is "author"}} blocks

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -12,10 +12,14 @@ const versions = require('../utils').versions;
 // discussion for the concrete false-negative cases a naive strip previously
 // introduced.
 //
+// `{{#if}}`/`{{#unless}}` are tracked as their own frame type so that a
+// nested `{{else}}` (which belongs to that if/unless, not the enclosing
+// `{{#is "author"}}`) never flips the outer is-block's active branch.
+//
 // Note: bare `{{author}}` (GS001-DEPR-AUTH) is intentionally NOT in the list
 // below - it's a removed helper, not a property access, so it renders
 // `[object Object]` even inside an author context and should never be exempt.
-const authorTagRegex = /{{!--[\s\S]*?--}}|{{!(?!--)[\s\S]*?}}|{{[#^]is\s+(['"])([\s\S]*?)\1\s*}}|{{\/is}}|{{else}}|{{#(?:foreach|each)\b[^}]*}}|{{\/(?:foreach|each)}}/g;
+const authorTagRegex = /{{!--[\s\S]*?--}}|{{!(?!--)[\s\S]*?}}|{{[#^]is\s+(['"])([\s\S]*?)\1\s*}}|{{\/is}}|{{else}}|{{#(?:foreach|each)\b[^}]*}}|{{\/(?:foreach|each)}}|{{[#^](?:if|unless)\b[^}]*}}|{{\/(?:if|unless)}}/g;
 
 function currentExempt(stack) {
     if (!stack.length) {
@@ -62,6 +66,10 @@ function getAuthorCheckableContent(content) {
                 elseExempt: ownElseExempt || exemptBefore
             });
         } else if (token === '{{else}}') {
+            // Only an `{{#is}}` frame's own `{{else}}` should switch its
+            // active branch - an `{{else}}` belonging to a nested
+            // `{{#if}}`/`{{#unless}}` (or `{{#foreach}}`/`{{#each}}`) frame
+            // must not leak through to the enclosing `is` frame.
             if (stack.length && stack[stack.length - 1].type === 'is') {
                 stack[stack.length - 1].inElse = true;
             }
@@ -76,6 +84,19 @@ function getAuthorCheckableContent(content) {
             stack.push({type: 'loop'});
         } else if (/^{{\/(?:foreach|each)}}/.test(token)) {
             if (stack.length && stack[stack.length - 1].type === 'loop') {
+                stack.pop();
+            }
+        } else if (/^{{[#^](?:if|unless)\b/.test(token)) {
+            // `{{#if}}`/`{{#unless}}` don't change author context - both of
+            // their branches inherit whatever exemption was already active.
+            stack.push({
+                type: 'cond',
+                inElse: false,
+                primaryExempt: exemptBefore,
+                elseExempt: exemptBefore
+            });
+        } else if (/^{{\/(?:if|unless)}}/.test(token)) {
+            if (stack.length && stack[stack.length - 1].type === 'cond') {
                 stack.pop();
             }
         }

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -7,14 +7,29 @@ const versions = require('../utils').versions;
 // default.hbs), so deprecation checks for those properties should ignore
 // content in these blocks. Tokenizes rather than doing a single blind regex
 // replace so that: multi-condition `{{#is}}` (an OR, so it isn't necessarily
-// author context), Handlebars comments, and nested `{{#is}}`/`{{#foreach}}`
-// blocks are all handled correctly - see #365 review discussion for the
-// concrete false-negative cases a naive strip previously introduced.
+// author context), Handlebars comments, nested `{{#is}}`/`{{#foreach}}`
+// blocks, and `{{else}}` branches are all handled correctly - see #365 review
+// discussion for the concrete false-negative cases a naive strip previously
+// introduced.
 //
 // Note: bare `{{author}}` (GS001-DEPR-AUTH) is intentionally NOT in the list
 // below - it's a removed helper, not a property access, so it renders
 // `[object Object]` even inside an author context and should never be exempt.
-const authorTagRegex = /{{!--[\s\S]*?--}}|{{!(?!--)[\s\S]*?}}|{{[#^]is\s+(['"])([\s\S]*?)\1\s*}}|{{\/is}}|{{#(?:foreach|each)\b[^}]*}}|{{\/(?:foreach|each)}}/g;
+const authorTagRegex = /{{!--[\s\S]*?--}}|{{!(?!--)[\s\S]*?}}|{{[#^]is\s+(['"])([\s\S]*?)\1\s*}}|{{\/is}}|{{else}}|{{#(?:foreach|each)\b[^}]*}}|{{\/(?:foreach|each)}}/g;
+
+function currentExempt(stack) {
+    if (!stack.length) {
+        return false;
+    }
+
+    const top = stack[stack.length - 1];
+
+    if (top.type === 'loop') {
+        return false;
+    }
+
+    return top.inElse ? top.elseExempt : top.primaryExempt;
+}
 
 function getAuthorCheckableContent(content) {
     const stack = [];
@@ -24,7 +39,7 @@ function getAuthorCheckableContent(content) {
 
     authorTagRegex.lastIndex = 0;
     while ((match = authorTagRegex.exec(content)) !== null) {
-        const exemptBefore = stack.length ? stack[stack.length - 1].exempt : false;
+        const exemptBefore = currentExempt(stack);
         result += exemptBefore ? '' : content.slice(lastIndex, match.index);
 
         const token = match[0];
@@ -33,8 +48,23 @@ function getAuthorCheckableContent(content) {
             // Handlebars comment: opaque, does not affect nesting/exemption.
         } else if (token.startsWith('{{#is') || token.startsWith('{{^is')) {
             const condition = (match[2] || '').trim();
-            const isSingleAuthorBlock = token.startsWith('{{#is') && condition === 'author';
-            stack.push({type: 'is', exempt: isSingleAuthorBlock || exemptBefore});
+            const isNegated = token.startsWith('{{^is');
+            const isSingleAuthorCondition = condition === 'author';
+            // {{#is "author"}}: author context before {{else}}, not after.
+            // {{^is "author"}}: the inverse - author context only after
+            // {{else}} (Ghost's {{#is}} supports {{else}} for both forms).
+            const ownPrimaryExempt = isSingleAuthorCondition && !isNegated;
+            const ownElseExempt = isSingleAuthorCondition && isNegated;
+            stack.push({
+                type: 'is',
+                inElse: false,
+                primaryExempt: ownPrimaryExempt || exemptBefore,
+                elseExempt: ownElseExempt || exemptBefore
+            });
+        } else if (token === '{{else}}') {
+            if (stack.length && stack[stack.length - 1].type === 'is') {
+                stack[stack.length - 1].inElse = true;
+            }
         } else if (token === '{{/is}}') {
             if (stack.length && stack[stack.length - 1].type === 'is') {
                 stack.pop();
@@ -43,7 +73,7 @@ function getAuthorCheckableContent(content) {
             // {{author}} inside a {{#foreach}}/{{#each}} refers to that
             // item's author relation, not the page-context author, even
             // when nested inside an {{#is "author"}} block - still checkable.
-            stack.push({type: 'loop', exempt: false});
+            stack.push({type: 'loop'});
         } else if (/^{{\/(?:foreach|each)}}/.test(token)) {
             if (stack.length && stack[stack.length - 1].type === 'loop') {
                 stack.pop();
@@ -54,7 +84,7 @@ function getAuthorCheckableContent(content) {
         lastIndex = authorTagRegex.lastIndex;
     }
 
-    const exemptAfter = stack.length ? stack[stack.length - 1].exempt : false;
+    const exemptAfter = currentExempt(stack);
     result += exemptAfter ? '' : content.slice(lastIndex);
 
     return result;

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -2,13 +2,65 @@ const _ = require('lodash');
 const spec = require('../specs');
 const versions = require('../utils').versions;
 
-// {{author}} and its properties are correctly available in the current context
-// while inside an {{#is "author"}}...{{/is}} block (e.g. in default.hbs), so
-// deprecation checks for those helpers should ignore content in these blocks.
-const authorIsBlockRegex = /{{#is\s+[^}]*\bauthor\b[^}]*}}[\s\S]*?{{\/is}}/g;
+// {{author.*}} properties are correctly available in the current context while
+// inside a single-condition {{#is "author"}}...{{/is}} block (e.g. in
+// default.hbs), so deprecation checks for those properties should ignore
+// content in these blocks. Tokenizes rather than doing a single blind regex
+// replace so that: multi-condition `{{#is}}` (an OR, so it isn't necessarily
+// author context), Handlebars comments, and nested `{{#is}}`/`{{#foreach}}`
+// blocks are all handled correctly - see #365 review discussion for the
+// concrete false-negative cases a naive strip previously introduced.
+//
+// Note: bare `{{author}}` (GS001-DEPR-AUTH) is intentionally NOT in the list
+// below - it's a removed helper, not a property access, so it renders
+// `[object Object]` even inside an author context and should never be exempt.
+const authorTagRegex = /{{!--[\s\S]*?--}}|{{!(?!--)[\s\S]*?}}|{{[#^]is\s+(['"])([\s\S]*?)\1\s*}}|{{\/is}}|{{#(?:foreach|each)\b[^}]*}}|{{\/(?:foreach|each)}}/g;
+
+function getAuthorCheckableContent(content) {
+    const stack = [];
+    let result = '';
+    let lastIndex = 0;
+    let match;
+
+    authorTagRegex.lastIndex = 0;
+    while ((match = authorTagRegex.exec(content)) !== null) {
+        const exemptBefore = stack.length ? stack[stack.length - 1].exempt : false;
+        result += exemptBefore ? '' : content.slice(lastIndex, match.index);
+
+        const token = match[0];
+
+        if (token.startsWith('{{!')) {
+            // Handlebars comment: opaque, does not affect nesting/exemption.
+        } else if (token.startsWith('{{#is') || token.startsWith('{{^is')) {
+            const condition = (match[2] || '').trim();
+            const isSingleAuthorBlock = token.startsWith('{{#is') && condition === 'author';
+            stack.push({type: 'is', exempt: isSingleAuthorBlock || exemptBefore});
+        } else if (token === '{{/is}}') {
+            if (stack.length && stack[stack.length - 1].type === 'is') {
+                stack.pop();
+            }
+        } else if (/^{{#(?:foreach|each)\b/.test(token)) {
+            // {{author}} inside a {{#foreach}}/{{#each}} refers to that
+            // item's author relation, not the page-context author, even
+            // when nested inside an {{#is "author"}} block - still checkable.
+            stack.push({type: 'loop', exempt: false});
+        } else if (/^{{\/(?:foreach|each)}}/.test(token)) {
+            if (stack.length && stack[stack.length - 1].type === 'loop') {
+                stack.pop();
+            }
+        }
+
+        result += token;
+        lastIndex = authorTagRegex.lastIndex;
+    }
+
+    const exemptAfter = stack.length ? stack[stack.length - 1].exempt : false;
+    result += exemptAfter ? '' : content.slice(lastIndex);
+
+    return result;
+}
 
 const authorContextAwareRules = [
-    'GS001-DEPR-AUTH',
     'GS001-DEPR-CON-AUTH',
     'GS001-DEPR-AUTH-ID',
     'GS001-DEPR-AUTH-SLUG',
@@ -28,7 +80,7 @@ const authorContextAwareRules = [
 
 function getCheckableContent(content, ruleCode) {
     if (authorContextAwareRules.includes(ruleCode)) {
-        return content.replace(authorIsBlockRegex, '');
+        return getAuthorCheckableContent(content);
     }
 
     return content;

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -2,6 +2,38 @@ const _ = require('lodash');
 const spec = require('../specs');
 const versions = require('../utils').versions;
 
+// {{author}} and its properties are correctly available in the current context
+// while inside an {{#is "author"}}...{{/is}} block (e.g. in default.hbs), so
+// deprecation checks for those helpers should ignore content in these blocks.
+const authorIsBlockRegex = /{{#is\s+[^}]*\bauthor\b[^}]*}}[\s\S]*?{{\/is}}/g;
+
+const authorContextAwareRules = [
+    'GS001-DEPR-AUTH',
+    'GS001-DEPR-CON-AUTH',
+    'GS001-DEPR-AUTH-ID',
+    'GS001-DEPR-AUTH-SLUG',
+    'GS001-DEPR-AUTH-MAIL',
+    'GS001-DEPR-AUTH-MT',
+    'GS001-DEPR-AUTH-MD',
+    'GS001-DEPR-AUTH-NAME',
+    'GS001-DEPR-AUTH-BIO',
+    'GS001-DEPR-AUTH-LOC',
+    'GS001-DEPR-AUTH-WEB',
+    'GS001-DEPR-AUTH-TW',
+    'GS001-DEPR-AUTH-FB',
+    'GS001-DEPR-AUTH-PIMG',
+    'GS001-DEPR-AUTH-CIMG',
+    'GS001-DEPR-AUTH-URL'
+];
+
+function getCheckableContent(content, ruleCode) {
+    if (authorContextAwareRules.includes(ruleCode)) {
+        return content.replace(authorIsBlockRegex, '');
+    }
+
+    return content;
+}
+
 const checkDeprecations = function checkDeprecations(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', versions.default);
     let ruleSet = spec.get([checkVersion]);
@@ -23,7 +55,7 @@ const checkDeprecations = function checkDeprecations(theme, options) {
             let cssDeprecations;
 
             if (template && !check.css && !skipTemplateCheck) {
-                if (themeFile.content.match(check.regex)) {
+                if (getCheckableContent(themeFile.content, ruleCode).match(check.regex)) {
                     if (!Object.prototype.hasOwnProperty.call(theme.results.fail, (ruleCode))) {
                         theme.results.fail[ruleCode] = {failures: []};
                     }

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3675,6 +3675,16 @@ describe('001 Deprecations', function () {
             });
         });
 
+        it('[success] should not flag {{author.*}} used inside an {{#is "author"}} block', function () {
+            return utils.testCheck(thisCheck, '001-deprecations/v6/valid-author-is-context', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                expect(output.results.fail).toEqual({});
+                utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-NAME');
+
+            });
+        });
+
         it('[failure] should detect deprecated facebook and twitter helper usage', function () {
             return utils.testCheck(thisCheck, '001-deprecations/v6/invalid/fb-twitter-helpers', options).then(function (output) {
                 utils.assertValidThemeObject(output);

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3681,6 +3681,37 @@ describe('001 Deprecations', function () {
 
                 expect(output.results.fail).toEqual({});
                 utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-NAME');
+                utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-BIO');
+
+            });
+        });
+
+        it('[failure] should still flag {{author.*}} usage that only looks author-scoped', function () {
+            return utils.testCheck(thisCheck, '001-deprecations/v6/invalid-author-is-context-edge-cases', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                // {{#is "index, author"}} is an OR - the block also renders on
+                // index pages where `author` is not in scope - and
+                // {{#foreach posts}}{{author.name}}{{/foreach}} refers to each
+                // post's author relation, not the page-context author - both
+                // remain genuine deprecations.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-NAME']);
+                const authNameFiles = output.results.fail['GS001-DEPR-AUTH-NAME'].failures.map(f => f.ref).sort();
+                expect(authNameFiles).toEqual(['foreach-shadow.hbs', 'multi-condition.hbs']);
+
+                // {{author.id}} preceded by a Handlebars comment that merely
+                // *mentions* {{#is "author"}} should not be treated as if it
+                // were inside a real author-is block.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-ID']);
+                expect(output.results.fail['GS001-DEPR-AUTH-ID'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-ID'].failures[0].ref).toEqual('comment-not-a-block.hbs');
+
+                // bare {{author}} is a removed helper, not a property access,
+                // and should never be exempted - even inside a genuine
+                // {{#is "author"}} block it renders [object Object].
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH']);
+                expect(output.results.fail['GS001-DEPR-AUTH'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH'].failures[0].ref).toEqual('bare-author-helper.hbs');
 
             });
         });

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3729,6 +3729,19 @@ describe('001 Deprecations', function () {
                 // {{^is "author"}} is genuine author context and stays exempt.
                 expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-WEB');
 
+                // A nested {{#if}}/{{#unless}} inside {{#is "author"}} does
+                // not change author context - both of its branches stay
+                // exempt, and its own {{else}} must not leak through to
+                // flip the enclosing is-block's active branch.
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-MAIL');
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-LOC');
+
+                // {{author.twitter}} inside an unrelated {{#unless}} outside
+                // any {{#is "author"}} block remains a genuine deprecation.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-TW']);
+                expect(output.results.fail['GS001-DEPR-AUTH-TW'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-TW'].failures[0].ref).toEqual('if-unless-nested.hbs');
+
             });
         });
 

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3713,6 +3713,22 @@ describe('001 Deprecations', function () {
                 expect(output.results.fail['GS001-DEPR-AUTH'].failures.length).toEqual(1);
                 expect(output.results.fail['GS001-DEPR-AUTH'].failures[0].ref).toEqual('bare-author-helper.hbs');
 
+                // {{#is "author"}} only grants exemption in its primary
+                // branch - the {{else}} branch is not author context.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-MT']);
+                expect(output.results.fail['GS001-DEPR-AUTH-MT'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-MT'].failures[0].ref).toEqual('else-branch.hbs');
+
+                // {{^is "author"}} is the inverse - author context is only
+                // in its {{else}} branch, not its primary branch.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-SLUG']);
+                expect(output.results.fail['GS001-DEPR-AUTH-SLUG'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-SLUG'].failures[0].ref).toEqual('else-branch.hbs');
+
+                // {{author.website}} inside the {{else}} branch of
+                // {{^is "author"}} is genuine author context and stays exempt.
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-WEB');
+
             });
         });
 

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/bare-author-helper.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/bare-author-helper.hbs
@@ -1,0 +1,3 @@
+{{#is "author"}}
+  {{author}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/comment-not-a-block.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/comment-not-a-block.hbs
@@ -1,0 +1,2 @@
+{{!-- {{#is "author"}} --}}
+{{author.id}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/else-branch.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/else-branch.hbs
@@ -1,0 +1,11 @@
+{{#is "author"}}
+  {{author.name}}
+{{else}}
+  {{author.meta_title}}
+{{/is}}
+
+{{^is "author"}}
+  {{author.slug}}
+{{else}}
+  {{author.website}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/foreach-shadow.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/foreach-shadow.hbs
@@ -1,0 +1,5 @@
+{{#is "author"}}
+  {{#foreach posts}}
+    {{author.name}}
+  {{/foreach}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/if-unless-nested.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/if-unless-nested.hbs
@@ -1,0 +1,11 @@
+{{#is "author"}}
+  {{#if foo}}
+    {{author.email}}
+  {{else}}
+    {{author.location}}
+  {{/if}}
+{{/is}}
+
+{{#unless bar}}
+  {{author.twitter}}
+{{/unless}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/multi-condition.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/multi-condition.hbs
@@ -1,0 +1,3 @@
+{{#is "index, author"}}
+  {{author.name}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
@@ -10,6 +10,12 @@
     {{#is "author"}}
       {{author.name}} | {{@site.title}}
     {{/is}}
+    {{#is "author"}}
+      {{#is "paged"}}
+        {{pagination.next}}
+      {{/is}}
+      {{author.bio}}
+    {{/is}}
     {{#is "tag"}}
       {{tag.name}} | {{@site.title}}
     {{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>
+    {{#is "home"}}
+      {{@site.title}} &mdash; {{@site.description}}
+    {{/is}}
+    {{#is "author"}}
+      {{author.name}} | {{@site.title}}
+    {{/is}}
+    {{#is "tag"}}
+      {{tag.name}} | {{@site.title}}
+    {{/is}}
+    {{^is "home, author, tag"}}
+      {{meta_title}} | {{@site.title}}
+    {{/is}}
+  </title>
+  {{ghost_head}}
+</head>
+
+<body>
+  {{{body}}}
+  {{ghost_foot}}
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #365

## Summary

`gscan` incorrectly flags `{{author.name}}` (and other `{{author.*}}` property accesses) as a deprecated helper usage even when it appears inside an `{{#is "author"}}...{{/is}}` block, e.g. in `default.hbs`:

```hbs
{{#is "author"}}
    {{author.name}} | {{@site.title}}
{{/is}}
```

This is valid, documented usage — inside an `{{#is "author"}}` block the current context genuinely is the Author object, so `{{author.name}}` (unlike `{{author.name}}` used elsewhere, e.g. inside a post loop) is correct and should not trigger the "Replace `{{author.name}}` with `{{primary_author.name}}` or `{{authors.[#].name}}`" deprecation error.

The regex-based `GS001-DEPR-AUTH-*` deprecation checks in `lib/checks/001-deprecations.js` didn't have any context awareness for this, unlike the `{{#author}}` block-helper rule which already excludes `author.hbs` via `notValidIn`.

## Fix

`lib/checks/001-deprecations.js` now strips out the contents of `{{#is "..."}}...{{/is}}` blocks that include `author` in their condition list before running the `GS001-DEPR-AUTH*` regex checks, so usage of `{{author}}`/`{{author.*}}` inside those blocks is no longer flagged, in any template (not just `author.hbs`).

## Tests

- Added a new fixture theme (`test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs`) reproducing the exact `default.hbs` snippet from the issue.
- Added a regression test in `test/001-deprecations.test.js` asserting no failures are reported for that fixture.
- Verified the new test fails without the fix (reproducing the reported false positive) and passes with it.
- Ran the full `001-deprecations` test suite (29/29 passing) and the full test suite (pre-existing, unrelated failure in `test/general.test.js` around `Thumbs.db` handling reproduces identically on `main` without this change).
- `eslint` clean on changed files.

### Test plan
- [x] `npx vitest run test/001-deprecations.test.js` — 29/29 passing
- [x] `npx vitest run` — same pass/fail counts as on `main` (1 pre-existing, unrelated failure)
- [x] `npx eslint lib/checks/001-deprecations.js test/001-deprecations.test.js` — clean