### PR TITLE
Allow {{#author}} block helper in author-:slug.hbs (#457)

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -18,7 +18,7 @@ const checkDeprecations = function checkDeprecations(theme, options) {
     _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
             const template = themeFile.file.match(/^.+\.hbs$/);
-            const skipTemplateCheck = check.notValidIn && themeFile.file.match(check.notValidIn);
+            const skipTemplateCheck = check.notValidIn && themeFile.normalizedFile.match(check.notValidIn);
             let css = themeFile.file.match(/\.css$/);
             let cssDeprecations;
 

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -18,7 +18,7 @@ const checkDeprecations = function checkDeprecations(theme, options) {
     _.each(ruleSet, function (check, ruleCode) {
         _.each(theme.files, function (themeFile) {
             const template = themeFile.file.match(/^.+\.hbs$/);
-            const skipTemplateCheck = check.notValidIn && check.notValidIn.match(template);
+            const skipTemplateCheck = check.notValidIn && themeFile.file.match(check.notValidIn);
             let css = themeFile.file.match(/\.css$/);
             let cssDeprecations;
 

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -71,7 +71,7 @@ let rules = {
         details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is deprecated and should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}helpers/authors/" target=_blank>here</a>.`,
         regex: /{{\s*?#author\s*?}}/g,
-        notValidIn: 'author.hbs',
+        notValidIn: /^author(-.+)?\.hbs$/,
         helper: '{{#author}}'
     },
     'GS001-DEPR-CON-AUTH': {

--- a/lib/specs/v2.js
+++ b/lib/specs/v2.js
@@ -68,7 +68,7 @@ let rules = {
     'GS001-DEPR-AUTHBL': {
         level: 'error',
         rule: 'Replace <code>{{#author}}</code> with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>',
-        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is deprecated and should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
+        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> or <code>author-:slug.hbs</code> is deprecated and should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
         Find more information about the <code>{{authors}}</code> helper <a href="${docsBaseUrl}helpers/authors/" target=_blank>here</a>.`,
         regex: /{{\s*?#author\s*?}}/g,
         notValidIn: /^author(-.+)?\.hbs$/,

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -539,7 +539,7 @@ let rules = {
         level: 'error',
         fatal: false,
         rule: 'The <code>{{#author}}</code> block helper should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>',
-        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> is no longer supported and
+        details: oneLineTrim`The usage of <code>{{#author}}</code> block helper outside of <code>author.hbs</code> or <code>author-:slug.hbs</code> is no longer supported and
         should be replaced with <code>{{#primary_author}}</code> or <code>{{#foreach authors}}...{{/foreach}}</code>.<br>
         ${multiAuthorDesc}<br>
         ${authorHelperDocs}`,

--- a/lib/specs/v5.js
+++ b/lib/specs/v5.js
@@ -544,7 +544,7 @@ let rules = {
         ${multiAuthorDesc}<br>
         ${authorHelperDocs}`,
         regex: /{{\s*?#author\s*?}}/g,
-        notValidIn: 'author.hbs',
+        notValidIn: /^author(-.+)?\.hbs$/,
         helper: '{{#author}}'
     },
     'GS001-DEPR-PAIMG': {

--- a/test/fixtures/themes/001-deprecations/v2/valid/author-april.hbs
+++ b/test/fixtures/themes/001-deprecations/v2/valid/author-april.hbs
@@ -1,0 +1,5 @@
+{{#author}}
+    {{name}}
+{{/author}}
+
+{{#is author}}{{/is}}

--- a/test/fixtures/themes/001-deprecations/v5/valid/author-april.hbs
+++ b/test/fixtures/themes/001-deprecations/v5/valid/author-april.hbs
@@ -1,0 +1,5 @@
+{{#author}}
+    {{name}}
+{{/author}}
+
+{{#is author}}{{/is}}


### PR DESCRIPTION
Fixes #457

## Summary

`gscan` incorrectly flags the `{{#author}}` block helper as deprecated (`GS001-DEPR-AUTHBL`) inside Ghost's documented `author-:slug.hbs` context templates (e.g. `author-april.hbs`), even though [Ghost's docs](https://ghost.org/docs/themes/contexts/author/) explicitly say `{{#author}}` is valid in both `author.hbs` and `author-:slug.hbs`.

## Root cause

The `GS001-DEPR-AUTHBL` rule (`lib/specs/v2.js`, `lib/specs/v5.js`) exempts `author.hbs` via a `notValidIn` string, but the check in `lib/checks/001-deprecations.js` matched it like this:

```js
const skipTemplateCheck = check.notValidIn && check.notValidIn.match(template);
```

`template` is the regex-match result array for the current filename, which JS coerces to a `RegExp` built from the filename when passed to `.match()`. So this line was actually testing whether the static string `"author.hbs"` matches a *pattern derived from the current filename* — backwards from what it looks like, and only "worked" by coincidence for the exact literal filename `author.hbs`. Any other filename such as `author-april.hbs` never matched, so the exemption never applied.

## Fix

- Changed `notValidIn` from the literal string `author.hbs` to a proper regex, `/^author(-.+)?\.hbs$/`, in both `lib/specs/v2.js` and `lib/specs/v5.js`, matching Ghost's own author-context documentation (`author.hbs` and `author-:slug.hbs`).
- Fixed `lib/checks/001-deprecations.js` to match the template filename against `notValidIn` directly (`themeFile.file.match(check.notValidIn)`), which is both correct for the new regex and no longer relies on the reversed-match coincidence.

I did not generalize `notValidIn` into a broader "literal-or-pattern" mechanism — it is only used by this one rule in both spec files, so a plain regex keeps the fix scoped to what's needed without adding unused flexibility.

Related: #891 fixed a sibling false positive in this same file (`{{author.*}}` property access inside `{{#is "author"}}` blocks) but intentionally left the `{{#author}}` block-helper `notValidIn` exemption untouched, so this PR does not overlap with it.

## Tests

- Added `author-april.hbs` (containing `{{#author}}...{{/author}}`) to the existing `v2/valid` and `v5/valid` fixture themes, alongside the already-present `author.hbs`.
- Verified against the pre-fix code that this reproduces the exact reported bug (`GS001-DEPR-AUTHBL` failure on `author-april.hbs`).
- Confirmed the existing `author.hbs` exemption and the existing `post.hbs` false-positive-catching fixture (`v5/invalid/post.hbs`, still flags `{{#author}}` outside an author context) both continue to pass unchanged.

### Test plan
- [x] `npx vitest run test/001-deprecations.test.js` — 28/28 passing
- [x] `npx vitest run` — same pass/fail counts as `main` (1 pre-existing, unrelated failure in `test/general.test.js` around `Thumbs.db` handling, reproduces identically without this change)
- [x] `npx eslint lib/checks/001-deprecations.js lib/specs/v2.js lib/specs/v5.js` — clean