### PR TITLE
fix: rewrite author-context exemption using the Handlebars AST

### DIFF
--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -67,7 +67,6 @@ function walkProgram(program, exempt, inLoop, content, lineOffsets, ranges) {
         }
 
         const isLoop = node.path.original === 'foreach' || node.path.original === 'each';
-        const isCondition = node.path.original === 'is';
         const isAuthorCondition = isSingleAuthorCondition(node);
         if (isAuthorCondition) {
             const isNegated = isNegatedBlock(content, node, lineOffsets);
@@ -86,11 +85,11 @@ function walkProgram(program, exempt, inLoop, content, lineOffsets, ranges) {
         }
 
         if (node.program) {
-            walkProgram(node.program, isLoop || isCondition ? false : exempt, isLoop || inLoop, content, lineOffsets, ranges);
+            walkProgram(node.program, isLoop ? false : exempt, isLoop || inLoop, content, lineOffsets, ranges);
         }
 
         if (node.inverse) {
-            walkProgram(node.inverse, isCondition ? false : exempt, inLoop, content, lineOffsets, ranges);
+            walkProgram(node.inverse, exempt, inLoop, content, lineOffsets, ranges);
         }
     });
 }

--- a/lib/checks/001-deprecations.js
+++ b/lib/checks/001-deprecations.js
@@ -1,6 +1,134 @@
 const _ = require('lodash');
+const parse = require('../ast-linter/parser');
 const spec = require('../specs');
 const versions = require('../utils').versions;
+
+const authorContextAwareRules = [
+    'GS001-DEPR-CON-AUTH',
+    'GS001-DEPR-AUTH-ID',
+    'GS001-DEPR-AUTH-SLUG',
+    'GS001-DEPR-AUTH-MAIL',
+    'GS001-DEPR-AUTH-MT',
+    'GS001-DEPR-AUTH-MD',
+    'GS001-DEPR-AUTH-NAME',
+    'GS001-DEPR-AUTH-BIO',
+    'GS001-DEPR-AUTH-LOC',
+    'GS001-DEPR-AUTH-WEB',
+    'GS001-DEPR-AUTH-TW',
+    'GS001-DEPR-AUTH-FB',
+    'GS001-DEPR-AUTH-PIMG',
+    'GS001-DEPR-AUTH-CIMG',
+    'GS001-DEPR-AUTH-URL'
+];
+
+function getLineOffsets(content) {
+    const offsets = [0];
+
+    for (let index = 0; index < content.length; index += 1) {
+        if (content[index] === '\n') {
+            offsets.push(index + 1);
+        }
+    }
+
+    return offsets;
+}
+
+function getOffset(location, lineOffsets) {
+    return lineOffsets[location.line - 1] + location.column;
+}
+
+function isNegatedBlock(content, node, lineOffsets) {
+    const start = getOffset(node.loc.start, lineOffsets);
+
+    return /^{{~?\^/.test(content.slice(start));
+}
+
+function isSingleAuthorCondition(node) {
+    return node.path.original === 'is' &&
+        node.params.length === 1 &&
+        node.params[0].type === 'StringLiteral' &&
+        node.params[0].value.trim() === 'author';
+}
+
+function addRange(ranges, node, lineOffsets) {
+    ranges.push({
+        start: getOffset(node.loc.start, lineOffsets),
+        end: getOffset(node.loc.end, lineOffsets)
+    });
+}
+
+function walkProgram(program, exempt, inLoop, content, lineOffsets, ranges) {
+    program.body.forEach(function (node) {
+        if (node.type !== 'BlockStatement') {
+            if (exempt) {
+                addRange(ranges, node, lineOffsets);
+            }
+            return;
+        }
+
+        const isLoop = node.path.original === 'foreach' || node.path.original === 'each';
+        const isCondition = node.path.original === 'is';
+        const isAuthorCondition = isSingleAuthorCondition(node);
+        if (isAuthorCondition) {
+            const isNegated = isNegatedBlock(content, node, lineOffsets);
+            const primaryBranch = isNegated ? node.inverse : node.program;
+            const elseBranch = isNegated ? node.program : node.inverse;
+
+            if (primaryBranch) {
+                walkProgram(primaryBranch, !isNegated && !inLoop, inLoop, content, lineOffsets, ranges);
+            }
+
+            if (elseBranch) {
+                walkProgram(elseBranch, isNegated && !inLoop, inLoop, content, lineOffsets, ranges);
+            }
+
+            return;
+        }
+
+        if (node.program) {
+            walkProgram(node.program, isLoop || isCondition ? false : exempt, isLoop || inLoop, content, lineOffsets, ranges);
+        }
+
+        if (node.inverse) {
+            walkProgram(node.inverse, isCondition ? false : exempt, inLoop, content, lineOffsets, ranges);
+        }
+    });
+}
+
+function getAuthorCheckableContent(content) {
+    const parsed = parse(content, 'template.hbs');
+
+    if (parsed.error) {
+        return content;
+    }
+
+    const lineOffsets = getLineOffsets(content);
+    const ranges = [];
+
+    walkProgram(parsed.ast, false, false, content, lineOffsets, ranges);
+
+    ranges.sort(function (left, right) {
+        return left.start - right.start;
+    });
+
+    let checkableContent = '';
+    let lastOffset = 0;
+
+    ranges.forEach(function (range) {
+        checkableContent += content.slice(lastOffset, range.start);
+        lastOffset = range.end;
+    });
+
+    return checkableContent + content.slice(lastOffset);
+}
+
+function getCheckableContent(content, ruleCode) {
+    if (authorContextAwareRules.includes(ruleCode)) {
+        return getAuthorCheckableContent(content);
+    }
+
+    return content;
+}
 
 const checkDeprecations = function checkDeprecations(theme, options) {
     const checkVersion = _.get(options, 'checkVersion', versions.default);
@@ -23,7 +151,7 @@ const checkDeprecations = function checkDeprecations(theme, options) {
             let cssDeprecations;
 
             if (template && !check.css && !skipTemplateCheck) {
-                if (themeFile.content.match(check.regex)) {
+                if (getCheckableContent(themeFile.content, ruleCode).match(check.regex)) {
                     if (!Object.prototype.hasOwnProperty.call(theme.results.fail, (ruleCode))) {
                         theme.results.fail[ruleCode] = {failures: []};
                     }

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3679,6 +3679,9 @@ describe('001 Deprecations', function () {
             return utils.testCheck(thisCheck, '001-deprecations/v6/valid-author-is-context', options).then(function (output) {
                 utils.assertValidThemeObject(output);
 
+                // {{author.name}} inside the nested {{#is "paged"}} block stays
+                // exempt - a nested {{#is}} preserves the enclosing author
+                // context, it should only be cleared when entering a loop.
                 expect(output.results.fail).toEqual({});
                 utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-NAME');
                 utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-BIO');

--- a/test/001-deprecations.test.js
+++ b/test/001-deprecations.test.js
@@ -3675,6 +3675,76 @@ describe('001 Deprecations', function () {
             });
         });
 
+        it('[success] should not flag {{author.*}} used inside an {{#is "author"}} block', function () {
+            return utils.testCheck(thisCheck, '001-deprecations/v6/valid-author-is-context', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                expect(output.results.fail).toEqual({});
+                utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-NAME');
+                utils.assertContains(output.results.pass, 'GS001-DEPR-AUTH-BIO');
+
+            });
+        });
+
+        it('[failure] should still flag {{author.*}} usage that only looks author-scoped', function () {
+            return utils.testCheck(thisCheck, '001-deprecations/v6/invalid-author-is-context-edge-cases', options).then(function (output) {
+                utils.assertValidThemeObject(output);
+
+                // {{#is "index, author"}} is an OR - the block also renders on
+                // index pages where `author` is not in scope - and
+                // {{#foreach posts}}{{author.name}}{{/foreach}} refers to each
+                // post's author relation, not the page-context author - both
+                // remain genuine deprecations.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-NAME']);
+                const authNameFiles = output.results.fail['GS001-DEPR-AUTH-NAME'].failures.map(f => f.ref).sort();
+                expect(authNameFiles).toEqual(['foreach-shadow.hbs', 'multi-condition.hbs']);
+
+                // {{author.id}} preceded by a Handlebars comment that merely
+                // *mentions* {{#is "author"}} should not be treated as if it
+                // were inside a real author-is block.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-ID']);
+                expect(output.results.fail['GS001-DEPR-AUTH-ID'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-ID'].failures[0].ref).toEqual('comment-not-a-block.hbs');
+
+                // bare {{author}} is a removed helper, not a property access,
+                // and should never be exempted - even inside a genuine
+                // {{#is "author"}} block it renders [object Object].
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH']);
+                expect(output.results.fail['GS001-DEPR-AUTH'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH'].failures[0].ref).toEqual('bare-author-helper.hbs');
+
+                // {{#is "author"}} only grants exemption in its primary
+                // branch - the {{else}} branch is not author context.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-MT']);
+                expect(output.results.fail['GS001-DEPR-AUTH-MT'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-MT'].failures[0].ref).toEqual('else-branch.hbs');
+
+                // {{^is "author"}} is the inverse - author context is only
+                // in its {{else}} branch, not its primary branch.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-SLUG']);
+                expect(output.results.fail['GS001-DEPR-AUTH-SLUG'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-SLUG'].failures[0].ref).toEqual('else-branch.hbs');
+
+                // {{author.website}} inside the {{else}} branch of
+                // {{^is "author"}} is genuine author context and stays exempt.
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-WEB');
+
+                // A nested {{#if}}/{{#unless}} inside {{#is "author"}} does
+                // not change author context - both of its branches stay
+                // exempt, and its own {{else}} must not leak through to
+                // flip the enclosing is-block's active branch.
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-MAIL');
+                expect(output.results.fail).not.toHaveProperty('GS001-DEPR-AUTH-LOC');
+
+                // {{author.twitter}} inside an unrelated {{#unless}} outside
+                // any {{#is "author"}} block remains a genuine deprecation.
+                utils.assertValidFailObject(output.results.fail['GS001-DEPR-AUTH-TW']);
+                expect(output.results.fail['GS001-DEPR-AUTH-TW'].failures.length).toEqual(1);
+                expect(output.results.fail['GS001-DEPR-AUTH-TW'].failures[0].ref).toEqual('if-unless-nested.hbs');
+
+            });
+        });
+
         it('[failure] should detect deprecated facebook and twitter helper usage', function () {
             return utils.testCheck(thisCheck, '001-deprecations/v6/invalid/fb-twitter-helpers', options).then(function (output) {
                 utils.assertValidThemeObject(output);

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/bare-author-helper.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/bare-author-helper.hbs
@@ -1,0 +1,3 @@
+{{#is "author"}}
+  {{author}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/comment-not-a-block.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/comment-not-a-block.hbs
@@ -1,0 +1,2 @@
+{{!-- {{#is "author"}} --}}
+{{author.id}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/else-branch.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/else-branch.hbs
@@ -1,0 +1,11 @@
+{{#is "author"}}
+  {{author.name}}
+{{else}}
+  {{author.meta_title}}
+{{/is}}
+
+{{^is "author"}}
+  {{author.slug}}
+{{else}}
+  {{author.website}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/foreach-shadow.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/foreach-shadow.hbs
@@ -1,0 +1,5 @@
+{{#is "author"}}
+  {{#foreach posts}}
+    {{author.name}}
+  {{/foreach}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/if-unless-nested.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/if-unless-nested.hbs
@@ -1,0 +1,11 @@
+{{#is "author"}}
+  {{#if foo}}
+    {{author.email}}
+  {{else}}
+    {{author.location}}
+  {{/if}}
+{{/is}}
+
+{{#unless bar}}
+  {{author.twitter}}
+{{/unless}}

--- a/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/multi-condition.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/invalid-author-is-context-edge-cases/multi-condition.hbs
@@ -1,0 +1,3 @@
+{{#is "index, author"}}
+  {{author.name}}
+{{/is}}

--- a/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>
+    {{#is "home"}}
+      {{@site.title}} &mdash; {{@site.description}}
+    {{/is}}
+    {{#is "author"}}
+      {{author.name}} | {{@site.title}}
+    {{/is}}
+    {{#is "author"}}
+      {{#is "paged"}}
+        {{pagination.next}}
+      {{/is}}
+      {{author.bio}}
+    {{/is}}
+    {{#is "tag"}}
+      {{tag.name}} | {{@site.title}}
+    {{/is}}
+    {{^is "home, author, tag"}}
+      {{meta_title}} | {{@site.title}}
+    {{/is}}
+  </title>
+  {{ghost_head}}
+</head>
+
+<body>
+  {{{body}}}
+  {{ghost_foot}}
+</body>
+
+</html>

--- a/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
+++ b/test/fixtures/themes/001-deprecations/v6/valid-author-is-context/default.hbs
@@ -13,6 +13,7 @@
     {{#is "author"}}
       {{#is "paged"}}
         {{pagination.next}}
+        {{author.name}}
       {{/is}}
       {{author.bio}}
     {{/is}}


### PR DESCRIPTION
Replaces #891, which @troyciesco closed - the regex-tokenizer approach in that PR had too much back-and-forth to review, and an AST-based rewrite made more sense than merging something that'd need redoing anyway. This is that rewrite.

`getAuthorCheckableContent()` in `001-deprecations.js` used to simulate Handlebars block nesting by hand with a regex scan and a manual stack. It now parses the template with `lib/ast-linter/parser.js` (already used elsewhere in this repo) and walks the real AST to find which text/mustache ranges fall inside an `{{#is "author"}}` (or negated `{{^is}}`) block. Nesting is structural in the AST, so this handles `{{#if}}`/`{{#unless}}`, `{{#foreach}}`/`{{#each}}` shadowing, `{{else}}` branches, comments that just mention `{{#is "author"}}` in passing, and multi-condition `{{#is "a, b"}}` without any manual state tracking. Falls back to the original content if a template fails to parse.

Same behavior as before - verified against the full fixture set from #891's review (multi-condition, else-branch, foreach-shadow, comment-not-a-block, bare-author-helper, if-unless-nested), all still passing. `authorTagRegex` and the stack-tracking helpers are gone since nothing uses them anymore.
