### PR TITLE
Make skipChecks actually skip the expensive read/parse work

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -31,7 +31,9 @@ function loadChecks() {
  * @param {string} [options.checkVersion] version to check the theme against
  * @param {string} [options.themeName] name of the checked theme
  * @param {Object=} [options.labs] object containing boolean flags for enabled labs features
- * @param {boolean} [options.skipChecks] flag to allow reading theme without incurring check costs
+ * @param {boolean} [options.skipChecks] flag to allow reading theme without incurring check costs -
+ *   also skips the AST parse and `.hbs`/`.css`/`.js` content reads inside `readTheme` that only
+ *   feed the rule checks (see `lib/read-theme.js`)
  * @param {Object=} [options.limits] zip extraction size limits
  * @returns {Promise<Object>}
  */
@@ -59,7 +61,7 @@ const check = async function checkAll(themePath, options = {}) {
     const readTheme = require('./read-theme');
 
     try {
-        const theme = await readTheme(themePath);
+        const theme = await readTheme(themePath, options);
 
         // set the major version to check
         theme.checkedVersion = versions[version].major;

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -43,9 +43,12 @@ const readThemeStructure = async function readThemeFiles(themePath, subPath, arr
     };
 
     const files = await fs.readdir(themePath, {withFileTypes: true});
-    let result = arr;
 
-    for (const dirent of files) {
+    // CASE: process every entry concurrently - each entry is pure I/O
+    // (readdir/rm) with no ordering dependency on its siblings. Results
+    // are still assembled in the original readdir order below, so the
+    // returned file list is unaffected by which entry resolves first.
+    const perEntryResults = await Promise.all(files.map(async function (dirent) {
         const file = dirent.name;
         const extMatch = file.match(/.*?(\.[0-9a-z]+$)/i);
         const subFilePath = path.join(subPath, file);
@@ -71,13 +74,23 @@ const readThemeStructure = async function readThemeFiles(themePath, subPath, arr
             if (inTmp) {
                 await fs.rm(newPath, {recursive: true, force: true});
             }
-            continue;
+            return [];
         }
 
         if (dirent.isDirectory()) {
-            result = await readThemeStructure(newPath, subFilePath, result);
-        } else {
-            result = makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());
+            return readThemeStructure(newPath, subFilePath, []);
+        }
+
+        return makeResult([], subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());
+    }));
+
+    // CASE: flatten in a single linear pass rather than repeatedly
+    // `.concat()`-ing onto the accumulator (which re-copies the whole
+    // accumulated array on every entry and is O(n^2) for a wide directory).
+    const result = arr;
+    for (const entryResult of perEntryResults) {
+        for (const item of entryResult) {
+            result.push(item);
         }
     }
 
@@ -85,11 +98,28 @@ const readThemeStructure = async function readThemeFiles(themePath, subPath, arr
 };
 
 /**
+ * Reads the content of theme files needed by the rule checks (and always
+ * derives `partials`/`customSettings`, which downstream consumers rely on
+ * regardless of `skipChecks`).
+ *
+ * When `options.skipChecks` is true, the rule checks in `lib/checks/*.js`
+ * never run, so nothing consumes `theme.helpers` or the raw `.css`/`.js`/
+ * `.hbs` file content - only `theme.partials`, `theme.templates`,
+ * `theme.customSettings`, `theme.path` and `theme.files` are read by callers.
+ * In that mode we skip the Handlebars AST parse (`ASTLinter.parse` /
+ * `processHelpers`) entirely and only read `package.json` off disk - partials
+ * are derived from file paths alone, and `.hbs`/`.css`/`.js` content is never
+ * read. This is a pure opt-in: with `skipChecks` unset/false, behavior is
+ * unchanged.
  *
  * @param {Theme} theme
+ * @param {Object} [options]
+ * @param {boolean} [options.skipChecks]
  * @returns {Promise<Theme>}
  */
-const readFiles = async function readFiles(theme) {
+const readFiles = async function readFiles(theme, options = {}) {
+    const skipChecks = options.skipChecks === true;
+
     const themeFilesContent = _.filter(theme.files, function (themeFile) {
         // CASE: never read the content of a symlinked entry - fs.readFile()
         // follows symlinks, so a symlink pointing outside the theme directory
@@ -97,6 +127,11 @@ const readFiles = async function readFiles(theme) {
         // always fatal for a theme (GS030-ASSET-SYM), so skipping their
         // content here costs nothing and closes that gap.
         if (themeFile && themeFile.ext && !themeFile.symlink) {
+            if (skipChecks) {
+                // CASE: only package.json content is needed for customSettings -
+                // .hbs/.css/.js content only feeds the rule checks, which don't run
+                return themeFile.file.match(/package.json/i);
+            }
             return themeFile.ext.match(/\.hbs|\.css|\.js/ig) || themeFile.file.match(/package.json/i);
         }
     });
@@ -106,6 +141,20 @@ const readFiles = async function readFiles(theme) {
 
     // Setup the helper object
     theme.helpers = {};
+
+    if (skipChecks) {
+        // CASE: partial names come from the file path alone, no content read required
+        theme.files.forEach((themeFile) => {
+            const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
+            if (partialMatch) {
+                theme.partials.push(partialMatch[1]);
+            }
+        });
+
+        // CASE: preserve the "customSettings always defined" guarantee even for
+        // themes without a package.json, matching non-skipChecks behavior
+        theme.customSettings = {};
+    }
 
     const themeRoot = path.resolve(theme.path);
 
@@ -134,6 +183,10 @@ const readFiles = async function readFiles(theme) {
             } catch (e) {
                 // Ignore error as they will be caught in 010-package-json.js
             }
+        }
+
+        if (skipChecks) {
+            return;
         }
 
         const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
@@ -252,9 +305,14 @@ const extractTemplates = function extractTemplates(allFiles) {
 /**
  *
  * @param {string} themePath - path to the validated theme
+ * @param {Object} [options]
+ * @param {boolean} [options.skipChecks] - when true, skips the Handlebars AST
+ *   parse and `.hbs`/`.css`/`.js` content reads that only feed the rule
+ *   checks (see `readFiles`); `partials`, `templates`, `customSettings`,
+ *   `path` and `files` are still populated as normal.
  * @returns {Promise<Theme>}
  */
-module.exports = async function readTheme(themePath) {
+module.exports = async function readTheme(themePath, options = {}) {
     const themeFiles = await readThemeStructure(themePath);
     const allTemplates = extractTemplates(themeFiles);
 
@@ -271,7 +329,7 @@ module.exports = async function readTheme(themePath) {
             pass: [],
             fail: {}
         }
-    });
+    }, options);
 };
 
 module.exports._private = {readFiles, readThemeStructure};
@@ -284,7 +342,9 @@ module.exports._private = {readFiles, readThemeStructure};
  * @param {Object[]} templates.all
  * @param {Object[]} templates.custom
  * @param {string[]} [partials]
- * @param {Object} helpers
+ * @param {Object} helpers - map of helper name -> files using it; empty when
+ *   `readTheme` was called with `options.skipChecks: true`, since it's only
+ *   populated as a byproduct of the AST parse done for the rule checks
  * @param {Object} results
  * @param {Object[]} results.pass
  * @param {Object} results.fail

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -3,7 +3,14 @@ const _ = require('lodash');
 const os = require('os');
 const path = require('path');
 const ASTLinter = require('./ast-linter');
-const {normalizePath, assertPathWithinRoot} = require('./utils');
+const {normalizePath, assertPathWithinRoot, createLimiter} = require('./utils');
+
+// CASE: bounds how many directory reads/removals can be in flight at once
+// across an entire readThemeStructure() walk (see below) - a directory with
+// many subdirectories would otherwise start a readdir for every one of them
+// concurrently, however wide/deep the tree, risking thread-pool congestion
+// and memory spikes.
+const MAX_CONCURRENT_DIR_READS = 64;
 
 const ignore = [
     'node_modules',
@@ -23,9 +30,10 @@ const linter = new ASTLinter({
     helpers: []
 });
 
-const readThemeStructure = async function readThemeFiles(themePath, subPath, arr) {
+const readThemeStructure = async function readThemeFiles(themePath, subPath, arr, limiter) {
     themePath = path.resolve(path.join(themePath, '.'));
     subPath = subPath || '';
+    limiter = limiter || createLimiter(MAX_CONCURRENT_DIR_READS);
 
     const tmpPath = os.tmpdir();
     const inTmp = themePath.substr(0, tmpPath.length) === tmpPath;
@@ -42,12 +50,18 @@ const readThemeStructure = async function readThemeFiles(themePath, subPath, arr
         return result;
     };
 
-    const files = await fs.readdir(themePath, {withFileTypes: true});
+    // CASE: throttled - see MAX_CONCURRENT_DIR_READS above. `limiter` is the
+    // same instance across the whole recursive walk (passed down below), so
+    // the cap applies tree-wide, not per directory.
+    const files = await limiter(() => fs.readdir(themePath, {withFileTypes: true}));
 
     // CASE: process every entry concurrently - each entry is pure I/O
     // (readdir/rm) with no ordering dependency on its siblings. Results
     // are still assembled in the original readdir order below, so the
     // returned file list is unaffected by which entry resolves first.
+    // Scheduling all of them here is cheap (just queues them on `limiter`,
+    // which bounds the actual filesystem work) regardless of how many
+    // entries a directory has.
     const perEntryResults = await Promise.all(files.map(async function (dirent) {
         const file = dirent.name;
         const extMatch = file.match(/.*?(\.[0-9a-z]+$)/i);
@@ -72,13 +86,13 @@ const readThemeStructure = async function readThemeFiles(themePath, subPath, arr
          */
         if (ignore.indexOf(file) > -1) {
             if (inTmp) {
-                await fs.rm(newPath, {recursive: true, force: true});
+                await limiter(() => fs.rm(newPath, {recursive: true, force: true}));
             }
             return [];
         }
 
         if (dirent.isDirectory()) {
-            return readThemeStructure(newPath, subFilePath, []);
+            return readThemeStructure(newPath, subFilePath, [], limiter);
         }
 
         return makeResult([], subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -142,9 +142,14 @@ const readFiles = async function readFiles(theme, options = {}) {
         // content here costs nothing and closes that gap.
         if (themeFile && themeFile.ext && !themeFile.symlink) {
             if (skipChecks) {
-                // CASE: only package.json content is needed for customSettings -
-                // .hbs/.css/.js content only feeds the rule checks, which don't run
-                return themeFile.file.match(/package.json/i);
+                // CASE: only the root package.json content is needed for
+                // customSettings - .hbs/.css/.js content only feeds the rule
+                // checks, which don't run. Exact match (not the loose
+                // /package.json/i used below) since skipChecks exists
+                // specifically to minimize reads - a nested/sibling file like
+                // vendor/package.json or assets/package.json.hbs shouldn't be
+                // read just because its name contains the substring.
+                return themeFile.file === 'package.json';
             }
             return themeFile.ext.match(/\.hbs|\.css|\.js/ig) || themeFile.file.match(/package.json/i);
         }

--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -157,8 +157,16 @@ const readFiles = async function readFiles(theme, options = {}) {
     theme.helpers = {};
 
     if (skipChecks) {
-        // CASE: partial names come from the file path alone, no content read required
+        // CASE: partial names come from the file path alone, no content read required.
+        // Symlinked entries are excluded here too, matching the non-skipChecks path
+        // below (themeFilesContent) - otherwise a symlinked partial would only be
+        // excluded from theme.partials when skipChecks is off, and this metadata is
+        // consumed downstream for theme activation regardless of skipChecks.
         theme.files.forEach((themeFile) => {
+            if (themeFile.symlink) {
+                return;
+            }
+
             const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
             if (partialMatch) {
                 theme.partials.push(partialMatch[1]);

--- a/lib/utils/create-limiter.js
+++ b/lib/utils/create-limiter.js
@@ -23,7 +23,11 @@ function createLimiter(max) {
         active += 1;
         const {fn, resolve, reject} = queue.shift();
 
-        fn().then(resolve, reject).finally(() => {
+        // CASE: defer the fn() call itself into the promise chain, so a
+        // synchronous throw from fn (not just a rejected promise) still
+        // reaches .finally() and releases this slot, instead of leaking it
+        // forever (and permanently stalling the queue if enough tasks do it).
+        Promise.resolve().then(fn).then(resolve, reject).finally(() => {
             active -= 1;
             runNext();
         });

--- a/lib/utils/create-limiter.js
+++ b/lib/utils/create-limiter.js
@@ -1,0 +1,40 @@
+/**
+ * Creates a simple counting-semaphore limiter: `limit(fn)` runs `fn`
+ * immediately if fewer than `max` calls are currently in flight, otherwise
+ * queues it (FIFO) until a slot frees up.
+ *
+ * Used to bound how many concurrent filesystem operations a recursive walk
+ * can have in flight at once, regardless of how wide/deep the tree is -
+ * unlike `Promise.all(items.map(doWork))`, which starts every operation
+ * immediately no matter how many `items` there are.
+ *
+ * @param {number} max - maximum concurrent executions of `fn`
+ * @returns {(fn: () => Promise<any>) => Promise<any>}
+ */
+function createLimiter(max) {
+    let active = 0;
+    const queue = [];
+
+    const runNext = function runNext() {
+        if (active >= max || queue.length === 0) {
+            return;
+        }
+
+        active += 1;
+        const {fn, resolve, reject} = queue.shift();
+
+        fn().then(resolve, reject).finally(() => {
+            active -= 1;
+            runNext();
+        });
+    };
+
+    return function limit(fn) {
+        return new Promise((resolve, reject) => {
+            queue.push({fn, resolve, reject});
+            runNext();
+        });
+    };
+}
+
+module.exports = createLimiter;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -18,5 +18,6 @@ module.exports = {
     versions: require('./versions.json'),
     normalizePath,
     getPackageJSON: require('./package-json'),
-    assertPathWithinRoot: require('./assert-path-within-root')
+    assertPathWithinRoot: require('./assert-path-within-root'),
+    createLimiter: require('./create-limiter')
 };

--- a/test/checker.test.js
+++ b/test/checker.test.js
@@ -62,6 +62,24 @@ describe('Checker', function () {
         });
     });
 
+    it('skipChecks skips the AST parse and content reads but keeps partials/templates/customSettings', function () {
+        return check(themePath('theme-with-custom-templates'), {checkVersion: 'v5', skipChecks: true}).then((theme) => {
+            utils.assertValidThemeObject(theme);
+
+            expect(theme.results.pass).toHaveLength(0);
+            expect(theme.results.fail).toEqual({});
+
+            expect(theme.helpers).toEqual({});
+
+            expect(theme.templates.all).toContain('post');
+            expect(theme.templates.custom.length).toEqual(4);
+
+            const hbsFile = theme.files.find(f => f.file === 'custom-My-Post.hbs');
+            expect(hbsFile.content).toBeUndefined();
+            expect(hbsFile.parsed).toBeUndefined();
+        });
+    });
+
     it('returns a valid theme when running all checks', function () {
         return check(themePath('is-empty'), {checkVersion: 'v2'}).then((theme) => {
             utils.assertValidThemeObject(theme);

--- a/test/create-limiter.test.js
+++ b/test/create-limiter.test.js
@@ -1,0 +1,89 @@
+const createLimiter = require('../lib/utils/create-limiter');
+
+describe('createLimiter', function () {
+    it('runs up to `max` tasks immediately', async function () {
+        const limit = createLimiter(2);
+        const order = [];
+        let releaseA;
+        let releaseB;
+
+        const a = limit(() => new Promise((resolve) => {
+            releaseA = resolve;
+        })).then(() => order.push('a'));
+        const b = limit(() => new Promise((resolve) => {
+            releaseB = resolve;
+        })).then(() => order.push('b'));
+
+        // both should have started synchronously (no third task to queue behind)
+        await Promise.resolve();
+        expect(releaseA).toBeDefined();
+        expect(releaseB).toBeDefined();
+
+        releaseA();
+        releaseB();
+        await Promise.all([a, b]);
+        expect(order).toEqual(['a', 'b']);
+    });
+
+    it('queues extra tasks until a slot frees up', async function () {
+        const limit = createLimiter(1);
+        const started = [];
+        let releaseFirst;
+
+        const first = limit(() => {
+            started.push('first');
+            return new Promise((resolve) => {
+                releaseFirst = resolve;
+            });
+        });
+        const second = limit(() => {
+            started.push('second');
+            return Promise.resolve();
+        });
+
+        // give the microtask queue a chance to run - `second` must NOT have started yet
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(started).toEqual(['first']);
+
+        releaseFirst();
+        await first;
+        await second;
+        expect(started).toEqual(['first', 'second']);
+    });
+
+    it('never exceeds `max` concurrent executions under load', async function () {
+        const limit = createLimiter(3);
+        let active = 0;
+        let peak = 0;
+
+        const tasks = Array.from({length: 20}, () => limit(() => {
+            active += 1;
+            peak = Math.max(peak, active);
+
+            return new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            }).then(() => {
+                active -= 1;
+            });
+        }));
+
+        await Promise.all(tasks);
+
+        expect(peak).toBeLessThanOrEqual(3);
+        // sanity check that tasks actually overlapped rather than running strictly
+        // one at a time (which would also satisfy the assertion above vacuously)
+        expect(peak).toBeGreaterThan(1);
+    });
+
+    it('propagates rejections without blocking the queue', async function () {
+        const limit = createLimiter(1);
+        const err = new Error('boom');
+
+        const first = limit(() => Promise.reject(err));
+        const second = limit(() => Promise.resolve('ok'));
+
+        await expect(first).rejects.toBe(err);
+        await expect(second).resolves.toEqual('ok');
+    });
+});

--- a/test/create-limiter.test.js
+++ b/test/create-limiter.test.js
@@ -86,4 +86,18 @@ describe('createLimiter', function () {
         await expect(first).rejects.toBe(err);
         await expect(second).resolves.toEqual('ok');
     });
+
+    it('releases the slot when fn throws synchronously, instead of leaking it', async function () {
+        const limit = createLimiter(1);
+        const err = new Error('boom');
+
+        const first = limit(() => {
+            throw err;
+        });
+        const second = limit(() => Promise.resolve('ok'));
+
+        await expect(first).rejects.toBe(err);
+        // if the slot leaked, `second` would never run and this would hang/timeout
+        await expect(second).resolves.toEqual('ok');
+    });
 });

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -316,6 +316,29 @@ describe('Read theme', function () {
             expect(theme.customSettings).toEqual({});
         });
 
+        it('excludes a symlinked partial from theme.partials the same way with or without skipChecks', async function () {
+            const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue('');
+            const files = () => [
+                {file: 'partials/legit.hbs', ext: '.hbs', symlink: false},
+                {file: 'partials/escape.hbs', ext: '.hbs', symlink: true}
+            ];
+
+            try {
+                const withSkipChecks = await readTheme._private.readFiles(
+                    {path: themePath('is-empty'), files: files()},
+                    {skipChecks: true}
+                );
+                const withoutSkipChecks = await readTheme._private.readFiles(
+                    {path: themePath('is-empty'), files: files()}
+                );
+
+                expect(withSkipChecks.partials).toEqual(['legit']);
+                expect(withoutSkipChecks.partials).toEqual(['legit']);
+            } finally {
+                readFileSpy.mockRestore();
+            }
+        });
+
         it('still returns correct templates.all and templates.custom', async function () {
             const theme = await readTheme(themePath('theme-with-custom-templates'), {skipChecks: true});
             utils.assertValidThemeObject(theme);

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -395,6 +395,31 @@ describe('Read theme', function () {
 
             expect(theme.customSettings).toEqual({});
         });
+
+        it('only reads the root package.json, not a same-named nested file or lookalike', async function () {
+            const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation(async (filePath) => {
+                if (filePath.endsWith('/package.json') && !filePath.includes('vendor')) {
+                    return '{"config":{"custom":{"from_root":{"type":"text","default":"yep"}}}}';
+                }
+                throw new Error(`unexpected read: ${filePath}`);
+            });
+
+            try {
+                const theme = await readTheme._private.readFiles({
+                    path: themePath('is-empty'),
+                    files: [
+                        {file: 'package.json', ext: '.json', symlink: false},
+                        {file: 'vendor/package.json', ext: '.json', symlink: false},
+                        {file: 'assets/package.json.hbs', ext: '.hbs', symlink: false}
+                    ]
+                }, {skipChecks: true});
+
+                expect(readFileSpy).toHaveBeenCalledTimes(1);
+                expect(theme.customSettings).toEqual({from_root: {type: 'text', default: 'yep'}});
+            } finally {
+                readFileSpy.mockRestore();
+            }
+        });
     });
 
     describe('without skipChecks (unchanged behavior)', function () {

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -263,4 +263,127 @@ describe('Read theme', function () {
             readdirSpy.mockRestore();
         }
     });
+
+    describe('with skipChecks', function () {
+        it('still returns correct partials, templates, and customSettings', async function () {
+            const theme = await readTheme(themePath('theme-with-partials'), {skipChecks: true});
+            utils.assertValidThemeObject(theme);
+
+            expect(theme.partials).toEqual(['mypartial', 'subfolder/test']);
+            expect(theme.templates.all).not.toContain('partials/mypartial');
+            expect(theme.templates.all).not.toContain('partials/subfolder/test');
+            expect(theme.customSettings).toEqual({});
+        });
+
+        it('still returns correct templates.all and templates.custom', async function () {
+            const theme = await readTheme(themePath('theme-with-custom-templates'), {skipChecks: true});
+            utils.assertValidThemeObject(theme);
+
+            expect(theme.templates.all).toEqual([
+                'custom/test',
+                'custom-My-Post',
+                'custom-about',
+                'my-page-about',
+                'page-1',
+                'page',
+                'podcast/rss',
+                'post-partials/footer',
+                'post-welcome-ghost',
+                'post'
+            ]);
+            expect(_.map(theme.templates.custom, 'filename')).toEqual([
+                'custom-My-Post',
+                'custom-about',
+                'page-1',
+                'post-welcome-ghost'
+            ]);
+        });
+
+        it('extracts customSettings from package.json without checks running', async function () {
+            const theme = await readTheme(themePath('theme-with-custom-settings'), {skipChecks: true});
+            utils.assertValidThemeObject(theme);
+
+            expect(theme.customSettings).toEqual({
+                test_select: {
+                    type: 'select',
+                    options: ['one', 'two'],
+                    default: 'two'
+                }
+            });
+        });
+
+        it('does not populate theme.helpers or read .hbs/.css/.js content', async function () {
+            const theme = await readTheme(themePath('theme-with-custom-templates'), {skipChecks: true});
+
+            expect(theme.helpers).toEqual({});
+
+            const hbsFile = theme.files.find(f => f.file === 'custom-My-Post.hbs');
+            const cssFile = theme.files.find(f => f.file === 'assets/styles.css');
+
+            expect(hbsFile.content).toBeUndefined();
+            expect(hbsFile.parsed).toBeUndefined();
+            expect(cssFile.content).toBeUndefined();
+        });
+
+        it('still reads package.json content for customSettings when no other files match', async function () {
+            const theme = await readTheme(themePath('010-packagejson/no-config'), {skipChecks: true});
+            utils.assertValidThemeObject(theme);
+
+            expect(theme.customSettings).toEqual({});
+        });
+    });
+
+    describe('without skipChecks (unchanged behavior)', function () {
+        it('still populates theme.helpers and file content', async function () {
+            const theme = await readTheme(themePath('theme-with-custom-templates'));
+
+            const hbsFile = theme.files.find(f => f.file === 'custom-My-Post.hbs');
+            const cssFile = theme.files.find(f => f.file === 'assets/styles.css');
+
+            expect(hbsFile.content).toEqual('content');
+            expect(hbsFile.parsed).toBeDefined();
+            expect(cssFile.content).toEqual('.some-class {\n    border: 0;\n}\n');
+        });
+    });
+
+    describe('directory walk ordering', function () {
+        it('returns files in the same order after parallelizing readThemeStructure', async function () {
+            const theme = await readTheme(themePath('theme-with-custom-templates'));
+
+            expect(theme.files.map(f => f.file)).toEqual([
+                'assets/ignoreme.hbs',
+                'assets/styles.css',
+                'custom/test.hbs',
+                'custom-My-Post.hbs',
+                'custom-about.hbs',
+                'my-page-about.hbs',
+                'package.json',
+                'page-1.hbs',
+                'page.hbs',
+                'podcast/rss.hbs',
+                'post-partials/footer.hbs',
+                'post-welcome-ghost.hbs',
+                'post.hbs'
+            ]);
+        });
+
+        it('assembles a wide directory in original readdir order without quadratic re-copying', async function () {
+            const entryCount = 5000;
+            const entries = Array.from({length: entryCount}, (entry, i) => ({
+                name: `file-${String(i).padStart(5, '0')}.hbs`,
+                isDirectory: () => false,
+                isSymbolicLink: () => false
+            }));
+            const readdirSpy = vi.spyOn(fs, 'readdir').mockResolvedValue(entries);
+
+            try {
+                const result = await readTheme._private.readThemeStructure(themePath('is-empty'));
+
+                expect(result).toHaveLength(entryCount);
+                expect(result.map(f => f.file)).toEqual(entries.map(e => e.name));
+            } finally {
+                readdirSpy.mockRestore();
+            }
+        });
+    });
 });

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -264,6 +264,47 @@ describe('Read theme', function () {
         }
     });
 
+    it('bounds concurrent directory reads across a wide tree instead of fanning out unboundedly', async function () {
+        const root = themePath('is-empty');
+        const dirCount = 200;
+        let activeReaddirs = 0;
+        let peakReaddirs = 0;
+
+        const readdirSpy = vi.spyOn(fs, 'readdir').mockImplementation(async (dirPath) => {
+            activeReaddirs += 1;
+            peakReaddirs = Math.max(peakReaddirs, activeReaddirs);
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 5);
+            });
+
+            activeReaddirs -= 1;
+
+            if (dirPath === root) {
+                return Array.from({length: dirCount}, (v, i) => ({
+                    name: `dir-${i}`,
+                    isDirectory: () => true,
+                    isSymbolicLink: () => false
+                }));
+            }
+
+            // leaf directories - nothing further to walk
+            return [];
+        });
+
+        try {
+            const result = await readTheme._private.readThemeStructure(root);
+
+            expect(result).toEqual([]);
+            // never more than the configured cap in flight at once...
+            expect(peakReaddirs).toBeLessThanOrEqual(64);
+            // ...but still genuinely running some of the 200 concurrently, not one-by-one
+            expect(peakReaddirs).toBeGreaterThan(1);
+        } finally {
+            readdirSpy.mockRestore();
+        }
+    });
+
     describe('with skipChecks', function () {
         it('still returns correct partials, templates, and customSettings', async function () {
             const theme = await readTheme(themePath('theme-with-partials'), {skipChecks: true});


### PR DESCRIPTION
Previously skipChecks:true only skipped the rule-check loop in
checker.js - readTheme still read every .css/.js/.hbs file's content
and ran the full Handlebars AST parse (theme.helpers) even though
nothing consumed that output.

- Thread options (skipChecks) from check() through readTheme() into
  readFiles(), which now skips the AST parse/processHelpers and the
  .hbs/.css/.js content reads when skipChecks is true, only reading
  package.json (for customSettings). partials are derived from file
  paths instead of content.
- Parallelize readThemeStructure's directory walk (Promise.all over
  readdir entries instead of a sequential .reduce() chain) - pure I/O
  win for both skipChecks and non-skipChecks callers.
- Add tests covering skipChecks correctness, unchanged non-skipChecks
  behavior, and stable file ordering after parallelizing the walk.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>