### PR TITLE
Convert lib/read-theme.js to async/await

### DIFF
--- a/lib/read-theme.js
+++ b/lib/read-theme.js
@@ -23,7 +23,7 @@ const linter = new ASTLinter({
     helpers: []
 });
 
-const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
+const readThemeStructure = async function readThemeFiles(themePath, subPath, arr) {
     themePath = path.join(themePath, '.');
     subPath = subPath || '';
 
@@ -42,45 +42,38 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
         return result;
     };
 
-    return fs.readdir(themePath, {withFileTypes: true}).then(function (files) {
-        let result = arr;
+    const files = await fs.readdir(themePath, {withFileTypes: true});
+    let result = arr;
 
-        return files.reduce(function (promise, dirent) {
-            return promise.then(function () {
-                const file = dirent.name;
-                const extMatch = file.match(/.*?(\.[0-9a-z]+$)/i);
-                const subFilePath = path.join(subPath, file);
-                const newPath = path.join(themePath, file);
+    for (const dirent of files) {
+        const file = dirent.name;
+        const extMatch = file.match(/.*?(\.[0-9a-z]+$)/i);
+        const subFilePath = path.join(subPath, file);
+        const newPath = path.join(themePath, file);
 
-                /**
-                 * don't process ignored paths, remove target file
-                 *
-                 * @TODO:
-                 * - gscan extracts the target zip into a tmp directory
-                 * - if you use gscan with `keepExtractedDir` the caller (Ghost) will use the tmp folder with the deleted ignore files
-                 * - what we don't support right now is to delete the ignore files from the zip
-                 */
-                if (ignore.indexOf(file) > -1) {
-                    return inTmp
-                        ? fs.rm(newPath, {recursive: true, force: true})
-                            .then(function () {
-                                return result;
-                            })
-                        : Promise.resolve(result);
-                }
+        /**
+         * don't process ignored paths, remove target file
+         *
+         * @TODO:
+         * - gscan extracts the target zip into a tmp directory
+         * - if you use gscan with `keepExtractedDir` the caller (Ghost) will use the tmp folder with the deleted ignore files
+         * - what we don't support right now is to delete the ignore files from the zip
+         */
+        if (ignore.indexOf(file) > -1) {
+            if (inTmp) {
+                await fs.rm(newPath, {recursive: true, force: true});
+            }
+            continue;
+        }
 
-                if (dirent.isDirectory()) {
-                    return readThemeStructure(newPath, subFilePath, result)
-                        .then((updatedResult) => {
-                            result = updatedResult;
-                        });
-                } else {
-                    result = makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());
-                    return Promise.resolve();
-                }
-            });
-        }, Promise.resolve()).then(() => result);
-    });
+        if (dirent.isDirectory()) {
+            result = await readThemeStructure(newPath, subFilePath, result);
+        } else {
+            result = makeResult(result, subFilePath, extMatch !== null ? extMatch[1] : undefined, dirent.isSymbolicLink());
+        }
+    }
+
+    return result;
 };
 
 /**
@@ -88,7 +81,7 @@ const readThemeStructure = function readThemeFiles(themePath, subPath, arr) {
  * @param {Theme} theme
  * @returns {Promise<Theme>}
  */
-const readFiles = function readFiles(theme) {
+const readFiles = async function readFiles(theme) {
     const themeFilesContent = _.filter(theme.files, function (themeFile) {
         if (themeFile && themeFile.ext) {
             return themeFile.ext.match(/\.hbs|\.css|\.js/ig) || themeFile.file.match(/package.json/i);
@@ -102,38 +95,39 @@ const readFiles = function readFiles(theme) {
     theme.helpers = {};
 
     // CASE: we need the actual content of all css, hbs files, and package.json for our checks
-    return Promise.all(themeFilesContent.map((themeFile) => {
-        return fs.readFile(path.join(theme.path, themeFile.file), 'utf8').then(function (content) {
-            themeFile.content = content;
+    await Promise.all(themeFilesContent.map(async (themeFile) => {
+        const content = await fs.readFile(path.join(theme.path, themeFile.file), 'utf8');
+        themeFile.content = content;
 
-            if (!theme.customSettings) {
-                theme.customSettings = {};
-            }
+        if (!theme.customSettings) {
+            theme.customSettings = {};
+        }
 
-            const packageJsonMatch = themeFile.file === 'package.json';
-            if (packageJsonMatch) {
-                try {
-                    const packageJson = JSON.parse(themeFile.content);
-                    if (packageJson.config && packageJson.config.custom) {
-                        theme.customSettings = packageJson.config.custom;
-                    }
-                } catch (e) {
-                    // Ignore error as they will be caught in 010-package-json.js
+        const packageJsonMatch = themeFile.file === 'package.json';
+        if (packageJsonMatch) {
+            try {
+                const packageJson = JSON.parse(themeFile.content);
+                if (packageJson.config && packageJson.config.custom) {
+                    theme.customSettings = packageJson.config.custom;
                 }
+            } catch (e) {
+                // Ignore error as they will be caught in 010-package-json.js
             }
+        }
 
-            const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
-            if (partialMatch) {
-                theme.partials.push(partialMatch[1]);
-            }
+        const partialMatch = themeFile.file.match(/^partials[/\\]+(.*)\.hbs$/);
+        if (partialMatch) {
+            theme.partials.push(partialMatch[1]);
+        }
 
-            const handlebarsMatch = themeFile.file.match(/\.hbs$/);
-            if (handlebarsMatch) {
-                themeFile.parsed = ASTLinter.parse(themeFile.content, themeFile.file);
-                processHelpers(theme, themeFile);
-            }
-        });
-    })).then(() => theme);
+        const handlebarsMatch = themeFile.file.match(/\.hbs$/);
+        if (handlebarsMatch) {
+            themeFile.parsed = ASTLinter.parse(themeFile.content, themeFile.file);
+            processHelpers(theme, themeFile);
+        }
+    }));
+
+    return theme;
 };
 
 const processHelpers = function (theme, themeFile) {
@@ -239,26 +233,24 @@ const extractTemplates = function extractTemplates(allFiles) {
  * @param {string} themePath - path to the validated theme
  * @returns {Promise<Theme>}
  */
-module.exports = function readTheme(themePath) {
-    return readThemeStructure(themePath)
-        .then(function (themeFiles) {
-            const allTemplates = extractTemplates(themeFiles);
+module.exports = async function readTheme(themePath) {
+    const themeFiles = await readThemeStructure(themePath);
+    const allTemplates = extractTemplates(themeFiles);
 
-            return readFiles({
-                path: themePath,
-                files: themeFiles,
-                templates: {
-                    all: allTemplates,
-                    custom: extractCustomTemplates(allTemplates)
-                },
-                // @TODO: there's no good reason to mix Object and Array formats.
-                //        They should be unified and use the one that suits best.
-                results: {
-                    pass: [],
-                    fail: {}
-                }
-            });
-        });
+    return readFiles({
+        path: themePath,
+        files: themeFiles,
+        templates: {
+            all: allTemplates,
+            custom: extractCustomTemplates(allTemplates)
+        },
+        // @TODO: there's no good reason to mix Object and Array formats.
+        //        They should be unified and use the one that suits best.
+        results: {
+            pass: [],
+            fail: {}
+        }
+    });
 };
 
 module.exports._private = {readFiles};

--- a/test/read-theme.test.js
+++ b/test/read-theme.test.js
@@ -6,43 +6,41 @@ const themePath = utils.themePath;
 
 describe('Read theme', function () {
 
-    it('returns correct result', function () {
-        return readTheme(themePath('is-empty')).then((theme) => {
-            utils.assertValidThemeObject(theme);
+    it('returns correct result', async function () {
+        const theme = await readTheme(themePath('is-empty'));
+        utils.assertValidThemeObject(theme);
 
-            expect(theme.files).toEqual([
-                {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
-                {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
-            ]);
-        });
+        expect(theme.files).toEqual([
+            {file: '.gitkeep', normalizedFile: '.gitkeep', ext: '.gitkeep', symlink: false},
+            {file: 'README.md', normalizedFile: 'README.md', ext: '.md', symlink: false}
+        ]);
     });
 
-    it('Can read partials', function () {
-        return readTheme(themePath('theme-with-partials')).then((theme) => {
-            utils.assertValidThemeObject(theme);
+    it('Can read partials', async function () {
+        const theme = await readTheme(themePath('theme-with-partials'));
+        utils.assertValidThemeObject(theme);
 
-            expect(theme.files).toHaveLength(7);
+        expect(theme.files).toHaveLength(7);
 
-            const fileNames = _.map(theme.files, function (file) {
-                return _.pickBy(file, function (value, key) {
-                    return key === 'file' || key === 'ext';
-                });
+        const fileNames = _.map(theme.files, function (file) {
+            return _.pickBy(file, function (value, key) {
+                return key === 'file' || key === 'ext';
             });
-
-            expect(fileNames).toContainEqual({file: 'index.hbs', ext: '.hbs'});
-            expect(fileNames).toContainEqual({file: 'package.json', ext: '.json'});
-            expect(fileNames).toContainEqual({file: 'partialsbroke.hbs', ext: '.hbs'});
-            expect(fileNames).toContainEqual({file: 'partials/mypartial.hbs', ext: '.hbs'});
-            expect(fileNames).toContainEqual({file: 'partials/subfolder/test.hbs', ext: '.hbs'});
-            expect(fileNames).toContainEqual({file: 'post.hbs', ext: '.hbs'});
-            expect(fileNames).toContainEqual({file: 'logo.new.hbs', ext: '.hbs'});
-
-            expect(theme.customSettings).toEqual({});
-
-            // partials should not appear in templates
-            expect(theme.templates.all).not.toContain('partials/mypartial');
-            expect(theme.templates.all).not.toContain('partials/subfolder/test');
         });
+
+        expect(fileNames).toContainEqual({file: 'index.hbs', ext: '.hbs'});
+        expect(fileNames).toContainEqual({file: 'package.json', ext: '.json'});
+        expect(fileNames).toContainEqual({file: 'partialsbroke.hbs', ext: '.hbs'});
+        expect(fileNames).toContainEqual({file: 'partials/mypartial.hbs', ext: '.hbs'});
+        expect(fileNames).toContainEqual({file: 'partials/subfolder/test.hbs', ext: '.hbs'});
+        expect(fileNames).toContainEqual({file: 'post.hbs', ext: '.hbs'});
+        expect(fileNames).toContainEqual({file: 'logo.new.hbs', ext: '.hbs'});
+
+        expect(theme.customSettings).toEqual({});
+
+        // partials should not appear in templates
+        expect(theme.templates.all).not.toContain('partials/mypartial');
+        expect(theme.templates.all).not.toContain('partials/subfolder/test');
     });
 
     it('can read partials with POSIX paths', async function () {
@@ -91,94 +89,91 @@ describe('Read theme', function () {
         }
     });
 
-    it('Can extract custom templates', function () {
-        return readTheme(themePath('theme-with-custom-templates')).then((theme) => {
-            utils.assertValidThemeObject(theme);
+    it('Can extract custom templates', async function () {
+        const theme = await readTheme(themePath('theme-with-custom-templates'));
+        utils.assertValidThemeObject(theme);
 
-            expect(theme.files).toHaveLength(13);
-            expect(theme.partials.length).toEqual(0);
-            expect(theme.templates.all.length).toEqual(10);
-            expect(theme.templates.custom.length).toEqual(4);
+        expect(theme.files).toHaveLength(13);
+        expect(theme.partials.length).toEqual(0);
+        expect(theme.templates.all.length).toEqual(10);
+        expect(theme.templates.custom.length).toEqual(4);
 
-            // ensure we don't change the structure of theme.files
-            expect(theme.files[0].file).toEqual('assets/ignoreme.hbs');
-            expect(theme.files[0].ext).toEqual('.hbs');
-            expect(theme.files[0].content).toEqual('ignoreme');
+        // ensure we don't change the structure of theme.files
+        expect(theme.files[0].file).toEqual('assets/ignoreme.hbs');
+        expect(theme.files[0].ext).toEqual('.hbs');
+        expect(theme.files[0].content).toEqual('ignoreme');
 
-            expect(theme.files[1].file).toEqual('assets/styles.css');
-            expect(theme.files[1].ext).toEqual('.css');
-            expect(theme.files[1].content).toEqual('.some-class {\n    border: 0;\n}\n');
+        expect(theme.files[1].file).toEqual('assets/styles.css');
+        expect(theme.files[1].ext).toEqual('.css');
+        expect(theme.files[1].content).toEqual('.some-class {\n    border: 0;\n}\n');
 
-            expect(theme.files[2].file).toEqual('custom/test.hbs');
-            expect(theme.files[2].ext).toEqual('.hbs');
-            expect(theme.files[2].content).toEqual('test');
+        expect(theme.files[2].file).toEqual('custom/test.hbs');
+        expect(theme.files[2].ext).toEqual('.hbs');
+        expect(theme.files[2].content).toEqual('test');
 
-            expect(theme.files[3].file).toEqual('custom-My-Post.hbs');
-            expect(theme.files[3].ext).toEqual('.hbs');
-            expect(theme.files[3].content).toEqual('content');
+        expect(theme.files[3].file).toEqual('custom-My-Post.hbs');
+        expect(theme.files[3].ext).toEqual('.hbs');
+        expect(theme.files[3].content).toEqual('content');
 
-            expect(theme.templates.all).toEqual([
-                'custom/test',
-                'custom-My-Post',
-                'custom-about',
-                'my-page-about',
-                'page-1',
-                'page',
-                'podcast/rss',
-                'post-partials/footer',
-                'post-welcome-ghost',
-                'post'
-            ]);
+        expect(theme.templates.all).toEqual([
+            'custom/test',
+            'custom-My-Post',
+            'custom-about',
+            'my-page-about',
+            'page-1',
+            'page',
+            'podcast/rss',
+            'post-partials/footer',
+            'post-welcome-ghost',
+            'post'
+        ]);
 
-            expect(_.map(theme.templates.custom, 'filename')).toEqual([
-                'custom-My-Post',
-                'custom-about',
-                'page-1',
-                'post-welcome-ghost'
-            ]);
+        expect(_.map(theme.templates.custom, 'filename')).toEqual([
+            'custom-My-Post',
+            'custom-about',
+            'page-1',
+            'post-welcome-ghost'
+        ]);
 
-            expect(theme.templates.custom[0].filename).toEqual('custom-My-Post');
-            expect(theme.templates.custom[0].name).toEqual('My Post');
-            expect(theme.templates.custom[0].for).toEqual(['page', 'post']);
-            expect(theme.templates.custom[0].slug).toBeNull();
+        expect(theme.templates.custom[0].filename).toEqual('custom-My-Post');
+        expect(theme.templates.custom[0].name).toEqual('My Post');
+        expect(theme.templates.custom[0].for).toEqual(['page', 'post']);
+        expect(theme.templates.custom[0].slug).toBeNull();
 
-            expect(theme.templates.custom[1].filename).toEqual('custom-about');
-            expect(theme.templates.custom[1].name).toEqual('About');
-            expect(theme.templates.custom[1].for).toEqual(['page', 'post']);
-            expect(theme.templates.custom[1].slug).toBeNull();
+        expect(theme.templates.custom[1].filename).toEqual('custom-about');
+        expect(theme.templates.custom[1].name).toEqual('About');
+        expect(theme.templates.custom[1].for).toEqual(['page', 'post']);
+        expect(theme.templates.custom[1].slug).toBeNull();
 
-            expect(theme.templates.custom[2].filename).toEqual('page-1');
-            expect(theme.templates.custom[2].name).toEqual('1');
-            expect(theme.templates.custom[2].for).toEqual(['page']);
-            expect(theme.templates.custom[2].slug).toEqual('1');
+        expect(theme.templates.custom[2].filename).toEqual('page-1');
+        expect(theme.templates.custom[2].name).toEqual('1');
+        expect(theme.templates.custom[2].for).toEqual(['page']);
+        expect(theme.templates.custom[2].slug).toEqual('1');
 
-            expect(theme.templates.custom[3].filename).toEqual('post-welcome-ghost');
-            expect(theme.templates.custom[3].name).toEqual('Welcome Ghost');
-            expect(theme.templates.custom[3].for).toEqual(['post']);
-            expect(theme.templates.custom[3].slug).toEqual('welcome-ghost');
+        expect(theme.templates.custom[3].filename).toEqual('post-welcome-ghost');
+        expect(theme.templates.custom[3].name).toEqual('Welcome Ghost');
+        expect(theme.templates.custom[3].for).toEqual(['post']);
+        expect(theme.templates.custom[3].slug).toEqual('welcome-ghost');
 
-            // nested and non-matching templates should not appear in custom
-            expect(_.map(theme.templates.custom, 'filename')).not.toContain('custom/test');
-            expect(_.map(theme.templates.custom, 'filename')).not.toContain('post');
-            expect(_.map(theme.templates.custom, 'filename')).not.toContain('page');
-            expect(_.map(theme.templates.custom, 'filename')).not.toContain('my-page-about');
-        });
+        // nested and non-matching templates should not appear in custom
+        expect(_.map(theme.templates.custom, 'filename')).not.toContain('custom/test');
+        expect(_.map(theme.templates.custom, 'filename')).not.toContain('post');
+        expect(_.map(theme.templates.custom, 'filename')).not.toContain('page');
+        expect(_.map(theme.templates.custom, 'filename')).not.toContain('my-page-about');
     });
 
-    it('can extract custom settings from package.json', function () {
-        return readTheme(themePath('theme-with-custom-settings')).then((theme) => {
-            utils.assertValidThemeObject(theme);
+    it('can extract custom settings from package.json', async function () {
+        const theme = await readTheme(themePath('theme-with-custom-settings'));
+        utils.assertValidThemeObject(theme);
 
-            expect(theme.customSettings).toBeDefined();
+        expect(theme.customSettings).toBeDefined();
 
-            expect(theme.customSettings).toEqual({
-                test_select: {
-                    type: 'select',
-                    options: ['one', 'two'],
-                    default: 'two'
-                }
-            });
-
+        expect(theme.customSettings).toEqual({
+            test_select: {
+                type: 'select',
+                options: ['one', 'two'],
+                default: 'two'
+            }
         });
     });
 


### PR DESCRIPTION
Mechanical conversion of the .then()/.catch() promise chains in
readThemeStructure, readFiles, and the readTheme export to async/await.
No behavior change - readThemeStructure still walks directory entries
sequentially (parallelizing that walk is a separate change layered on
top of this one).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>