### PR TITLE
Migrate from the glob package to Node's native fs.glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.13.1, 24]
+        node-version: [22.17.0, 24]
     env:
       CI: true
       FORCE_COLOR: 1

--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -1,8 +1,8 @@
 const debug = require('@tryghost/debug')('zip');
 const path = require('path');
 const os = require('os');
+const fs = require('fs/promises');
 const {randomUUID} = require('crypto');
-const {glob} = require('glob');
 const {extract} = require('@tryghost/zip');
 const errors = require('@tryghost/errors');
 const _ = require('lodash');
@@ -15,12 +15,22 @@ const resolveBaseDir = async (zipPath) => {
     let matches = [];
 
     try {
-        matches = await glob('**/index.hbs', {cwd: zipPath, nosort: true});
+        matches = await Array.fromAsync(fs.glob('**/index.hbs', {cwd: zipPath}));
     } catch (err) {
         debug('Glob match error while resolving zip base dir', err);
     }
 
     if (!_.isEmpty(matches)) {
+        // CASE: fs.glob() makes no ordering guarantee (the old `glob` package
+        // call used `nosort: true` here too, so this was already unordered) -
+        // sort by path depth so the shallowest index.hbs wins deterministically
+        // for a malformed zip with more than one match, rather than whichever
+        // the filesystem happened to enumerate first.
+        matches.sort((a, b) => {
+            const depthDiff = a.split('/').length - b.split('/').length;
+            return depthDiff !== 0 ? depthDiff : a.localeCompare(b);
+        });
+
         debug('Found matches', matches);
         const matchedPath = matches[0].replace(/index\.hbs$/, '');
         zipPath = path.join(zipPath, matchedPath).replace(/\/$/, '');
@@ -67,3 +77,4 @@ const readZip = (zip, options = {}) => {
 };
 
 module.exports = readZip;
+module.exports._private = {resolveBaseDir};

--- a/lib/read-zip.js
+++ b/lib/read-zip.js
@@ -11,6 +11,18 @@ const isKnownZipError = (err) => {
     return errors.utils.isGhostError(err);
 };
 
+/**
+ * Comparator for sorting glob matches by path depth, shallowest first, with
+ * an alphabetical tiebreak at equal depth (for deterministic results when a
+ * malformed zip has more than one match). Depth is computed on a
+ * separator-neutral split since fs.glob returns OS-native-separated paths
+ * (backslash on Windows), not always '/'.
+ */
+const compareMatchDepth = (a, b) => {
+    const depthDiff = a.split(/[\\/]/).length - b.split(/[\\/]/).length;
+    return depthDiff !== 0 ? depthDiff : a.localeCompare(b);
+};
+
 const resolveBaseDir = async (zipPath) => {
     let matches = [];
 
@@ -23,17 +35,15 @@ const resolveBaseDir = async (zipPath) => {
     if (!_.isEmpty(matches)) {
         // CASE: fs.glob() makes no ordering guarantee (the old `glob` package
         // call used `nosort: true` here too, so this was already unordered) -
-        // sort by path depth so the shallowest index.hbs wins deterministically
-        // for a malformed zip with more than one match, rather than whichever
-        // the filesystem happened to enumerate first.
-        matches.sort((a, b) => {
-            const depthDiff = a.split('/').length - b.split('/').length;
-            return depthDiff !== 0 ? depthDiff : a.localeCompare(b);
-        });
+        // pick the shallowest index.hbs deterministically rather than
+        // whichever the filesystem happened to enumerate first.
+        matches.sort(compareMatchDepth);
 
         debug('Found matches', matches);
-        const matchedPath = matches[0].replace(/index\.hbs$/, '');
-        zipPath = path.join(zipPath, matchedPath).replace(/\/$/, '');
+        // CASE: path.dirname()/path.join() are platform-native, so they stay
+        // correct for whichever separator fs.glob actually returned on this
+        // OS - a manual regex strip assuming '/' would break on Windows.
+        zipPath = path.join(zipPath, path.dirname(matches[0]));
     }
 
     return zipPath;
@@ -77,4 +87,4 @@ const readZip = (zip, options = {}) => {
 };
 
 module.exports = readZip;
-module.exports._private = {resolveBaseDir};
+module.exports._private = {resolveBaseDir, compareMatchDepth};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "engines": {
-    "node": "^22.13.1 || ^24.0.0"
+    "node": "^22.17.0 || ^24.0.0"
   },
   "bugs": {
     "url": "https://github.com/TryGhost/gscan/issues"
@@ -55,7 +55,6 @@
     "chalk": "6.0.0",
     "express": "5.2.1",
     "express-handlebars": "8.0.1",
-    "glob": "13.0.6",
     "handlebars": "4.7.9",
     "lodash": "4.18.1",
     "multer": "2.3.0",

--- a/test/read-zip.test.js
+++ b/test/read-zip.test.js
@@ -261,4 +261,30 @@ describe('Zip file handler can read zip files', function () {
             }
         });
     });
+
+    // These test the comparator directly (rather than through resolveBaseDir,
+    // which also calls the platform-native path.dirname()/path.join() - those
+    // only parse backslashes as separators when actually running on Windows)
+    // so the separator-neutral depth sort can be verified on any OS running
+    // this test suite, including with Windows-style ("\\") match strings.
+    describe('compareMatchDepth', function () {
+        it('sorts POSIX-separated matches by depth, shallowest first', function () {
+            const matches = ['deep/nested/index.hbs', 'shallow/index.hbs'];
+            matches.sort(readZip._private.compareMatchDepth);
+            expect(matches).toEqual(['shallow/index.hbs', 'deep/nested/index.hbs']);
+        });
+
+        it('sorts Windows-separated matches by depth, shallowest first', function () {
+            const matches = ['deep\\nested\\index.hbs', 'shallow\\index.hbs'];
+            matches.sort(readZip._private.compareMatchDepth);
+            expect(matches).toEqual(['shallow\\index.hbs', 'deep\\nested\\index.hbs']);
+        });
+
+        it('breaks ties alphabetically at equal depth, for POSIX or Windows separators', function () {
+            expect(['zeta/index.hbs', 'alpha/index.hbs'].sort(readZip._private.compareMatchDepth))
+                .toEqual(['alpha/index.hbs', 'zeta/index.hbs']);
+            expect(['zeta\\index.hbs', 'alpha\\index.hbs'].sort(readZip._private.compareMatchDepth))
+                .toEqual(['alpha\\index.hbs', 'zeta\\index.hbs']);
+        });
+    });
 });

--- a/test/read-zip.test.js
+++ b/test/read-zip.test.js
@@ -220,4 +220,45 @@ describe('Zip file handler can read zip files', function () {
             mocked.restore();
         }
     });
+
+    describe('resolveBaseDir', function () {
+        it('picks the shallowest index.hbs when multiple matches exist at different depths', async function () {
+            const globSpy = vi.spyOn(fs, 'glob').mockReturnValue([
+                'deep/nested/index.hbs',
+                'shallow/index.hbs'
+            ]);
+
+            try {
+                const result = await readZip._private.resolveBaseDir('/some/zip/path');
+                expect(result).toEqual('/some/zip/path/shallow');
+            } finally {
+                globSpy.mockRestore();
+            }
+        });
+
+        it('breaks ties between equally-deep matches alphabetically, for deterministic results', async function () {
+            const globSpy = vi.spyOn(fs, 'glob').mockReturnValue([
+                'zeta/index.hbs',
+                'alpha/index.hbs'
+            ]);
+
+            try {
+                const result = await readZip._private.resolveBaseDir('/some/zip/path');
+                expect(result).toEqual('/some/zip/path/alpha');
+            } finally {
+                globSpy.mockRestore();
+            }
+        });
+
+        it('returns the input path unchanged when there is no match', async function () {
+            const globSpy = vi.spyOn(fs, 'glob').mockReturnValue([]);
+
+            try {
+                const result = await readZip._private.resolveBaseDir('/some/zip/path');
+                expect(result).toEqual('/some/zip/path');
+            } finally {
+                globSpy.mockRestore();
+            }
+        });
+    });
 });

--- a/test/valid-doc-links.js
+++ b/test/valid-doc-links.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* eslint-disable no-console */
 const path = require('path');
-const glob = require('glob');
+const fs = require('fs');
 const {default: chalk} = require('chalk');
 
 const checkIds = process.env.GSCAN_DOC_CHECK_IDS !== 'false';
@@ -198,7 +198,7 @@ function summarize(summaries, otherErrors) {
 const semaphore = new Semaphore(5);
 
 async function run() {
-    const allSpecs = glob.sync('*.js', {cwd: SPEC_ROOT, ignore: 'index.js'});
+    const allSpecs = fs.globSync('*.js', {cwd: SPEC_ROOT}).filter(f => f !== 'index.js');
 
     /** @type {Record<string, Set<string>>} */
     const linksToCheck = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,15 +2094,6 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@13.0.6:
-  version "13.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
-  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
-  dependencies:
-    minimatch "^10.2.2"
-    minipass "^7.1.3"
-    path-scurry "^2.0.2"
-
 glob@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.1.0.tgz#4f826576e4eb99c7dad383793d2f9f08f67e50a6"
@@ -2767,7 +2758,7 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^7.1.2, minipass@^7.1.3:
+minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
@@ -3022,7 +3013,7 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^2.0.0, path-scurry@^2.0.2:
+path-scurry@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
   integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==


### PR DESCRIPTION
## What & why

Node's `fsPromises.glob`/`fs.globSync` became stable (no longer behind an experimental flag/warning) in v22.17.0. Bumps the `engines.node` floor to `^22.17.0 || ^24.0.0` and moves both of gscan's `glob` usages to the built-in, dropping the `glob` dependency.

Split out as its own PR (ahead of #909) per review discussion there - the Node-floor bump and dependency replacement stand alone, then the `readThemeStructure` bounded-concurrency rewrite (addressing the unbounded directory-read fan-out flagged on #909) lands on top of this.

## Changes

- `engines.node` bumped, CI matrix's pinned 22.x version bumped to match
- `lib/read-zip.js`: `glob('**/index.hbs', {cwd, nosort: true})` → `fs.glob()` + `Array.fromAsync`. The old call already made no ordering guarantee (`nosort: true`); for the edge case of a malformed zip with more than one `index.hbs`, matches are now sorted by path depth (then alphabetically) and the shallowest wins - deterministic where before it was whatever order the old library happened to return.
- `test/valid-doc-links.js`: `glob.sync('*.js', {ignore: ...})` → `fs.globSync()` + a manual filter (the native `exclude` option didn't behave as documented in local testing).
- `glob` removed from `dependencies`; `yarn.lock` updated.
- `resolveBaseDir` exposed via `module.exports._private` in `read-zip.js`, with new unit tests for the depth-sort and its tiebreak (no existing fixture covered the multi-match case).

## Testing

- `yarn test` (437 tests, all green)
- `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)