### PR TITLE
Fix publish workflow: yarn chokes on unset NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,16 @@ jobs:
       FORCE_COLOR: 1
       CI: true
       NPM_CONFIG_PROVENANCE: true
+      # actions/setup-node's registry-url input always writes an .npmrc
+      # referencing ${NODE_AUTH_TOKEN} for the registry auth line, regardless
+      # of auth method. We publish via npm OIDC Trusted Publishing (see
+      # `permissions: id-token: write` above), so no token secret is ever
+      # set - npm itself tolerates that fine at publish time, but yarn
+      # classic (v1, used for install and to run `ship:ci` below) fails hard
+      # on any unresolved env var reference in .npmrc. An empty value here
+      # satisfies yarn's substitution without providing (or needing) a real
+      # token.
+      NODE_AUTH_TOKEN: ''
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## What broke

The v6.5.0 publish run failed at the first `yarn install` step:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```
([failed run](https://github.com/TryGhost/gscan/actions/runs/33801474953))

## Why

`actions/setup-node`'s `registry-url` input always writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}` for the registry auth line, regardless of auth method. This workflow publishes via **npm OIDC Trusted Publishing** (`permissions: id-token: write`, npm 11, `NPM_CONFIG_PROVENANCE: true`) and never sets a `NODE_AUTH_TOKEN` secret — npm itself tolerates the unresolved reference fine at publish time, but **yarn classic (v1)**, used here both to install dependencies and to run `ship:ci`, fails hard on any unresolved env var reference in `.npmrc`.

This started with the `actions/setup-node` v5→v7 bump ([`e97ba5d`](https://github.com/TryGhost/gscan/commit/e97ba5d), 2026-07-15 23:29 UTC) — landing *after* v6.4.2's last successful publish (17:34 UTC same day) and before this, the first publish attempt since. v7 apparently generates the `.npmrc` auth line in a way the previous version didn't hit the same way.

## Fix

Set `NODE_AUTH_TOKEN: ''` at the job level. An empty value satisfies yarn's substitution without providing (or needing) a real token, since actual publish auth goes through OIDC regardless.

Validated with `actionlint` (clean).

This repo will eventually move to pnpm, which doesn't have this yarn-classic quirk — this just unblocks publishing in the meantime.

## Testing

Can't fully exercise the publish path without tagging a release, but the specific failing step (`yarn install` reading the auto-generated `.npmrc`) is directly addressed. Recommend a `workflow_dispatch` dry-run before the next real tag push to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)